### PR TITLE
Removes klee_make_symbolic/get_value calls from port I/O operations

### DIFF
--- a/klee/lib/Core/SpecialFunctionHandler.cpp
+++ b/klee/lib/Core/SpecialFunctionHandler.cpp
@@ -47,19 +47,18 @@ struct HandlerInfo {
 // especially things like realloc which have complicated semantics
 // w.r.t. forking. Among other things this makes delayed query
 // dispatch easier to implement.
-HandlerInfo handlerInfo[] = {
+HandlerInfo handlerInfo[] = { // XXX TODO: Remove all of this
 #define add(name, handler, ret) { name, \
                                   &SpecialFunctionHandler::handler, \
                                   false, ret, false }
 #define addDNR(name, handler) { name, \
                                 &SpecialFunctionHandler::handler, \
                                 true, false, false }
-
+//S2E: no need for these...
+#if 0
   add("klee_get_value", handleGetValue, true),
   add("klee_make_symbolic", handleMakeSymbolic, false),
 
-//S2E: no need for these...
-#if 0
   addDNR("__assert_rtn", handleAssertFail),
   addDNR("__assert_fail", handleAssertFail),
   addDNR("_assert", handleAssert),

--- a/qemu/llvm-lib.h
+++ b/qemu/llvm-lib.h
@@ -43,30 +43,11 @@
 
 #define LLVMLIB_H
 
-void klee_make_symbolic(void *addr, unsigned nbytes, const char *name);
-uint8_t klee_int8(const char *name);
-uint16_t klee_int16(const char *name);
-uint32_t klee_int32(const char *name);
 void uint32_to_string(uint32_t n, char *str);
 void trace_port(char *buf, const char *prefix, uint32_t port, uint32_t pc);
 
-uint8_t klee_int8(const char *name) {
-    uint8_t ret;
-    klee_make_symbolic(&ret, sizeof(ret), name);
-    return ret;
-}
-
-uint16_t klee_int16(const char *name) {
-    uint16_t ret;
-    klee_make_symbolic(&ret, sizeof(ret), name);
-    return ret;
-}
-
-uint32_t klee_int32(const char *name) {
-    uint32_t ret;
-    klee_make_symbolic(&ret, sizeof(ret), name);
-    return ret;
-}
+void tcg_llvm_make_symbolic(void *addr, unsigned nbytes, const char *name);
+void tcg_llvm_get_value(void *addr, unsigned nbytes, bool addConstraint);
 
 //Helpers to avoid relying on sprintf that does not work properly
 static char hextable[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b',

--- a/qemu/s2e/S2EExecutionState.h
+++ b/qemu/s2e/S2EExecutionState.h
@@ -245,6 +245,18 @@ public:
     /** Write concrete value to general purpose CPU register */
     void writeCpuRegisterConcrete(unsigned offset, const void* buf, unsigned size);
 
+    /** Handler for tcg_llvm_make_symbolic, tcg_llvm_get_value. */
+    void makeSymbolic(std::vector< klee::ref<klee::Expr> > &args,
+                      bool makeConcolic);
+    void kleeReadMemory(klee::ref<klee::Expr> kleeAddressExpr,
+                        uint64_t sizeInBytes,
+                        std::vector<klee::ref<klee::Expr> > *result,
+                        bool concreteOnly = false,
+                        bool concretize = false,
+                        bool addConstraint = false);
+    void kleeWriteMemory(klee::ref<klee::Expr> kleeAddressExpr,
+                         std::vector<klee::ref<klee::Expr> > &bytes);
+
     /** Read CPU system state */
     uint64_t readCpuState(unsigned offset, unsigned width) const;
 

--- a/qemu/s2e/S2EExecutor.h
+++ b/qemu/s2e/S2EExecutor.h
@@ -245,6 +245,16 @@ protected:
                                          klee::KInstruction* target,
                                          std::vector<klee::ref<klee::Expr> > &args);
 
+    static void handleMakeSymbolic(klee::Executor* executor,
+                                   klee::ExecutionState* state,
+                                   klee::KInstruction* target,
+                                   std::vector<klee::ref<klee::Expr> > &args);
+
+    static void handleGetValue(klee::Executor* executor,
+                               klee::ExecutionState* state,
+                               klee::KInstruction* target,
+                               std::vector<klee::ref<klee::Expr> > &args);
+    
     void prepareFunctionExecution(S2EExecutionState *state,
                            llvm::Function* function,
                            const std::vector<klee::ref<klee::Expr> >& args);

--- a/qemu/s2e/s2e_qemu.h
+++ b/qemu/s2e/s2e_qemu.h
@@ -357,6 +357,8 @@ void tcg_llvm_trace_memory_access(uint64_t vaddr, uint64_t haddr,
                                   uint8_t isWrite, uint8_t isIo);
 void tcg_llvm_trace_port_access(uint64_t port, uint64_t value,
                                 unsigned bits, int isWrite);
+void tcg_llvm_make_symbolic(void *addr, unsigned nbytes, const char *name);
+void tcg_llvm_get_value(void *addr, unsigned nbytes, bool addConstraint);
 //#endif
 
 

--- a/qemu/softmmu_template.h
+++ b/qemu/softmmu_template.h
@@ -176,7 +176,7 @@ inline DATA_TYPE glue(glue(io_read_chk, SUFFIX), MMUSUFFIX)(ENV_PARAM target_phy
 
 inline DATA_TYPE glue(io_make_symbolic, SUFFIX)(const char *name) {
     uint8_t ret;
-    klee_make_symbolic(&ret, sizeof(ret), name);
+    tcg_llvm_make_symbolic(&ret, sizeof(ret), name);
     return ret;
 }
 

--- a/qemu/target-i386/op_helper.c
+++ b/qemu/target-i386/op_helper.c
@@ -755,13 +755,14 @@ void helper_check_iol(uint32_t t0)
 void helper_outb(uint32_t port, uint32_t data)
 {
     if (g_s2e_concretize_io_addresses) {
-        port = klee_get_value(port);
+        tcg_llvm_get_value(&port, sizeof(port), false);
     }
 
     tcg_llvm_trace_port_access(port, data, 8, 1);
     if (!s2e_is_port_symbolic(g_s2e, g_s2e_state, port)) {
         if (g_s2e_concretize_io_writes) {
-            data = klee_get_value(data & 0xFF);
+            data &= 0xFF;
+            tcg_llvm_get_value(&data, sizeof(data), false);
         }
 
         cpu_outb(port, data & 0xff);
@@ -771,13 +772,14 @@ void helper_outb(uint32_t port, uint32_t data)
 target_ulong helper_inb(uint32_t port)
 {
     if (g_s2e_concretize_io_addresses) {
-        port = klee_get_value(port);
+        tcg_llvm_get_value(&port, sizeof(port), false);
     }
 
     if (s2e_is_port_symbolic(g_s2e, g_s2e_state, port)) {
         char label[64];
+        uint8_t res;
         trace_port(label, "inb", port, env->eip);
-        uint8_t res = klee_int8(label);
+        tcg_llvm_make_symbolic(&res, sizeof (uint8_t), label);
         tcg_llvm_trace_port_access(port, res, 8, 0);
         return res;
     }
@@ -790,13 +792,14 @@ target_ulong helper_inb(uint32_t port)
 void helper_outw(uint32_t port, uint32_t data)
 {
     if (g_s2e_concretize_io_addresses) {
-        port = klee_get_value(port);
+        tcg_llvm_get_value(&port, sizeof(port), false);
     }
 
     tcg_llvm_trace_port_access(port, data, 16, 1);
     if (!s2e_is_port_symbolic(g_s2e, g_s2e_state, port)) {
         if (g_s2e_concretize_io_writes) {
-            data = klee_get_value(data & 0xFFFF);
+            data &= 0xFFFF; 
+            tcg_llvm_get_value(&data, sizeof(data), false);
         }
 
         cpu_outw(port, data & 0xffff);
@@ -806,13 +809,14 @@ void helper_outw(uint32_t port, uint32_t data)
 target_ulong helper_inw(uint32_t port)
 {
     if (g_s2e_concretize_io_addresses) {
-        port = klee_get_value(port);
+        tcg_llvm_get_value(&port, sizeof(port), false);
     }
 
     if (s2e_is_port_symbolic(g_s2e, g_s2e_state, port)) {
         char label[64];
+        uint16_t res;
         trace_port(label, "inw", port, env->eip);
-        uint16_t res = klee_int16(label);
+        tcg_llvm_make_symbolic(&res, sizeof (uint16_t), label);
         tcg_llvm_trace_port_access(port, res, 16, 0);
         return res;
     }
@@ -824,13 +828,14 @@ target_ulong helper_inw(uint32_t port)
 void helper_outl(uint32_t port, uint32_t data)
 {
     if (g_s2e_concretize_io_addresses) {
-        port = klee_get_value(port);
+        tcg_llvm_get_value(&port, sizeof(port), false);
     }
 
     tcg_llvm_trace_port_access(port, data, 32, 1);
     if (!s2e_is_port_symbolic(g_s2e, g_s2e_state, port)) {
         if (g_s2e_concretize_io_writes) {
-            data = klee_get_value(data);
+            data &= 0xFFFFFFFF;
+            tcg_llvm_get_value(&data, sizeof(data), false);
         }
 
         cpu_outl(port, data);
@@ -840,13 +845,14 @@ void helper_outl(uint32_t port, uint32_t data)
 target_ulong helper_inl(uint32_t port)
 {
     if (g_s2e_concretize_io_addresses) {
-        port = klee_get_value(port);
+        tcg_llvm_get_value(&port, sizeof(port), false);
     }
 
     if (s2e_is_port_symbolic(g_s2e, g_s2e_state, port)) {
         char label[64];
+        uint32_t res;
         trace_port(label, "inl", port, env->eip);
-        uint32_t res = klee_int32(label);
+        tcg_llvm_make_symbolic(&res, sizeof (uint32_t), label);
         tcg_llvm_trace_port_access(port, res, 32, 0);
         return res;
     }

--- a/qemu/tcg/tcg-llvm.cpp
+++ b/qemu/tcg/tcg-llvm.cpp
@@ -131,6 +131,8 @@ struct TCGLLVMContextPrivate {
     Function *m_helperTraceMemoryAccess;
     Function *m_helperTraceInstruction;
     Function *m_helperForkAndConcretize;
+    Function *m_helperMakeSymbolic;
+    Function *m_helperGetValue;
     Function* m_qemu_ld_helpers[5];
     Function* m_qemu_st_helpers[5];
 #endif
@@ -394,6 +396,11 @@ void TCGLLVMContextPrivate::initializeHelpers()
     m_helperForkAndConcretize =
             m_module->getFunction("tcg_llvm_fork_and_concretize");
 
+    m_helperMakeSymbolic =
+            m_module->getFunction("tcg_llvm_make_symbolic");
+    m_helperGetValue =
+            m_module->getFunction("tcg_llvm_get_value");
+
     m_qemu_ld_helpers[0] = m_module->getFunction("__ldb_mmu");
     m_qemu_ld_helpers[1] = m_module->getFunction("__ldw_mmu");
     m_qemu_ld_helpers[2] = m_module->getFunction("__ldl_mmu");
@@ -407,6 +414,8 @@ void TCGLLVMContextPrivate::initializeHelpers()
     m_qemu_st_helpers[4] = m_module->getFunction("__stq_mmu");
 
     assert(m_helperTraceMemoryAccess);
+    assert(m_helperMakeSymbolic);
+    assert(m_helperGetValue);
     for(int i = 0; i < 5; ++i) {
         assert(m_qemu_ld_helpers[i]);
         assert(m_qemu_st_helpers[i]);


### PR DESCRIPTION
This patch removes the klee_make_symbolic and klee_get_value calls
from the port I/O code, and removes these function implements
altogether.  The old approach was not compatible with conconcolic
execution.  This patch removes related code from the KLEE
SpecialFunctionHandler.cpp.

New functionality includes the handleMakeSymbolic and handleGetValue
calls in S2EExecutor, as well as the makeSymbolic and
kleeRead/WriteMemory calls in S2EExecutionState.
