### PR TITLE
stp build changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,11 @@ stamps/stp-configure stamps/stp-configure-asan: | stamps
 stamps/stp-make stamps/stp-make-asan: ALWAYS
 
 STP_CONFIGURE_FLAGS = --with-prefix=$(S2EBUILD)/stp --with-fpic \
-                      --with-g++=$(CLANG_CXX) --with-gcc=$(CLANG_CC)
+                      --with-g++=$(CLANG_CXX) --with-gcc=$(CLANG_CC) \
+                      --with-cryptominisat2
 
 stamps/stp-configure: | stp
-	cd stp && scripts/configure $(STP_CONFIGURE_FLAGS) --with-cryptominisat2
+	cd stp && scripts/configure $(STP_CONFIGURE_FLAGS)
 	touch $@
 
 stamps/stp-make: $(CLANG_CXX) stamps/stp-configure


### PR DESCRIPTION
Enabling cryptominisat only for the non-asan case looked like an oversight in the llvm 3.2 porting effort.

This also refactors the stp configuration flags to avoid code duplication.
