### PR TITLE
PerStateOutput plugin

### DIFF
--- a/docs/Plugins/PerStateOutput.html
+++ b/docs/Plugins/PerStateOutput.html
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="Docutils 0.8.1: http://docutils.sourceforge.net/" />
+<title>PerStateOutput</title>
+<link rel="stylesheet" href="../s2e.css" type="text/css" />
+</head>
+<body>
+<div class="document" id="perstateoutput">
+<h1 class="title">PerStateOutput</h1>
+
+<p>This plugin splits log and debug output across one directory for
+each symbolic state.</p>
+<div class="section" id="setting-up-perstateoutput-plugin">
+<h1>Setting up PerStateOutput Plugin</h1>
+<p>To enable the <tt class="docutils literal">PerStateOutput</tt> plugin in the S2E configuration file,
+add the following lines to your <tt class="docutils literal">config.lua</tt> file:</p>
+<div class="highlight"><pre><span class="n">plugins</span> <span class="o">=</span> <span class="p">{</span>
+  <span class="o">..</span><span class="p">.</span>
+  <span class="s2">&quot;</span><span class="s">PerStateOutput&quot;</span>
+<span class="p">}</span>
+</pre></div>
+</div>
+</div>
+<div class="footer">
+<hr class="footer" />
+<a class="reference external" href="PerStateOutput.rst">View document source</a>.
+
+</div>
+</body>
+</html>

--- a/docs/Plugins/PerStateOutput.rst
+++ b/docs/Plugins/PerStateOutput.rst
@@ -1,0 +1,19 @@
+==============
+PerStateOutput
+==============
+
+This plugin splits log and debug output across one directory for
+each symbolic state.
+
+Setting up PerStateOutput Plugin
+================================
+
+To enable the ``PerStateOutput`` plugin in the S2E configuration file,
+add the following lines to your ``config.lua`` file:
+
+.. code-block:: lua
+
+   plugins = {
+     ...
+     "PerStateOutput"
+   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,6 +121,7 @@ how to combine these tracers.</p>
 <ul class="simple">
 <li><a class="reference external" href="Plugins/FunctionMonitor.html">FunctionMonitor</a> provides client plugins with events triggered when the guest code invokes specified functions.</li>
 <li><a class="reference external" href="UsingS2EGet.html">HostFiles</a> allows to quickly upload files to the guest.</li>
+<li><a class="reference external" href="Plugins/PerStateOutput.html">PerStateOutput</a> splits log and debug output into one directory per symbolic state.</li>
 </ul>
 </div>
 </div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ Miscellaneous Plugins
 
 * `FunctionMonitor <Plugins/FunctionMonitor.html>`_ provides client plugins with events triggered when the guest code invokes specified functions.
 * `HostFiles <UsingS2EGet.html>`_ allows to quickly upload files to the guest.
+* `PerStateOutput <Plugins/PerStateOutput.html>`_ splits S2E log and debug output into one directory per symbolic state.
 
 S²E Development
 ===============

--- a/qemu/Makefile.target
+++ b/qemu/Makefile.target
@@ -464,6 +464,7 @@ s2eobj-y += s2e/Plugins/LibraryCallMonitor.o
 s2eobj-y += s2e/Plugins/InterruptInjector.o
 s2eobj-y += s2e/Plugins/BaseInstructions.o
 s2eobj-y += s2e/Plugins/X86ExceptionInterceptor.o
+s2eobj-y += s2e/Plugins/PerStateOutput.o
 s2eobj-y += s2e/Plugins/WindowsInterceptor/WindowsMonitor.o
 s2eobj-y += s2e/Plugins/WindowsInterceptor/BlueScreenInterceptor.o
 s2eobj-y += s2e/Plugins/WindowsInterceptor/WindowsCrashDumpGenerator.o

--- a/qemu/s2e/Plugins/PerStateOutput.cpp
+++ b/qemu/s2e/Plugins/PerStateOutput.cpp
@@ -1,0 +1,84 @@
+/*
+ * S2E Selective Symbolic Execution Platform
+ *
+ * Copyright (c) 2013, Diego Biurrun <diego@biurrun.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * All contributors are listed in the S2E-AUTHORS file.
+ */
+
+#include <sstream>
+#include <string>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Path.h>
+#include <s2e/S2E.h>
+#include <s2e/Utils.h>
+
+#include "PerStateOutput.h"
+
+namespace s2e {
+namespace plugins {
+
+S2E_DEFINE_PLUGIN(PerStateOutput,
+                  "Split output into per state subdirectories",
+                  "PerStateOutput",);
+
+void PerStateOutput::resetOutputDirectory(int state_id)
+{
+    std::stringstream next_state_stream;
+    next_state_stream << state_id;
+
+    llvm::sys::Path output_path(llvm::sys::path::parent_path(s2e()->getOutputDirectoryBase()));
+    output_path.appendComponent("state_" + next_state_stream.str());
+
+    std::string output_dir = output_path.str();
+    s2e()->setOutputDirectoryBase(output_dir);
+    s2e()->initOutputDirectory(output_dir, 0, 1);
+}
+
+PerStateOutput::PerStateOutput(S2E* s2e): Plugin(s2e)
+{
+}
+
+void PerStateOutput::initialize()
+{
+    llvm::sys::Path output_path(s2e()->getOutputDirectoryBase());
+    output_path.appendComponent("state_0");
+    std::string output_dir(output_path.str());
+    s2e()->setOutputDirectoryBase(output_dir);
+    s2e()->initOutputDirectory(output_dir, 0, 1);
+
+    s2e()->getCorePlugin()->onStateSwitch.connect(
+        sigc::mem_fun(*this, &PerStateOutput::onStateSwitch));
+}
+
+void PerStateOutput::onStateSwitch(S2EExecutionState *current,
+                                   S2EExecutionState *next)
+{
+    resetOutputDirectory(next->getID());
+}
+
+} // namespace plugins
+} // namespace s2e

--- a/qemu/s2e/Plugins/PerStateOutput.h
+++ b/qemu/s2e/Plugins/PerStateOutput.h
@@ -1,0 +1,60 @@
+/*
+ * S2E Selective Symbolic Execution Platform
+ *
+ * Copyright (c) 2013, Diego Biurrun <diego@biurrun.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * All contributors are listed in the S2E-AUTHORS file.
+ */
+
+#ifndef S2E_PLUGINS_PERSTATEOUTPUT_H
+#define S2E_PLUGINS_PERSTATEOUTPUT_H
+
+#include <s2e/ConfigFile.h>
+#include <s2e/Plugin.h>
+#include <s2e/S2E.h>
+#include <s2e/Plugins/CorePlugin.h>
+#include <s2e/S2EExecutionState.h>
+
+namespace s2e {
+namespace plugins {
+
+class PerStateOutput : public Plugin {
+    S2E_PLUGIN;
+
+    void initialize();
+    void onStateSwitch(S2EExecutionState *current,
+                       S2EExecutionState *next);
+
+    void resetOutputDirectory(int state_id);
+
+public:
+    PerStateOutput(S2E *s2e);
+};
+
+} // namespace plugins
+} // namespace s2e
+
+#endif /* S2E_PLUGINS_PERSTATEOUTPUT_H */

--- a/qemu/s2e/S2E.h
+++ b/qemu/s2e/S2E.h
@@ -136,9 +136,6 @@ protected:
        Such resources are inherited from the parent process. */
     bool m_forking;
 
-    /* forked indicates whether the current S2E process was forked from a parent S2E process */
-    void initOutputDirectory(const std::string& outputDirectory, int verbose, bool forked);
-
     void initKleeOptions();
     void initExecutor();
     void initPlugins();
@@ -172,8 +169,17 @@ public:
     /*************************/
     /* Directories and files */
 
+    /* forked indicates whether the current S2E process was forked from a parent S2E process */
+    void initOutputDirectory(const std::string& outputDirectory, int verbose, bool forked);
+
     /** Get output directory name */
     const std::string& getOutputDirectory() const { return m_outputDirectory; }
+
+    /** Get base output directory name */
+    const std::string& getOutputDirectoryBase() const { return m_outputDirectoryBase; }
+
+    /** Set base output directory name. */
+    void setOutputDirectoryBase(std::string new_name) { m_outputDirectoryBase = new_name; }
 
     /** Get a filename inside an output directory */
     std::string getOutputFilename(const std::string& fileName);


### PR DESCRIPTION
So here is a simple plugin that I find useful during my experiments with S2E: splitting debug and log output across one directory for each symbolic state instead of having everything appended into one monolithic debug/log/etc. file.

I'm sure there are much more elegant ways to implement this; I'm all ears for suggestions.  I can, however, confirm that this worked satisfactorily for me...

Signed-off-by: Diego Biurrun diego@biurrun.de
