### PR TITLE
build guest tools for native x86 architecture variant

### DIFF
--- a/guest/Makefile
+++ b/guest/Makefile
@@ -1,17 +1,15 @@
-BINARIES = demos/quicksort init_env/init_env.so init_env/init_env64.so  s2ecmd/s2ecmd s2eget/s2eget
+BINARIES = demos/quicksort init_env/init_env.so s2ecmd/s2ecmd s2eget/s2eget
 CCFLAGS  = -Iinclude -Wall -g -O0 -std=c99
 LDLIBS   = -ldl
 
 all: $(BINARIES)
 
-demos/quicksort init_env/init_env.so s2ecmd/s2ecmd s2eget/s2eget : CFLAGS+=-m32
-init_env/init_env64.so: CFLAGS+=-m64
 s2ecmd/s2ecmd s2eget/s2eget: include/s2e.h
 
 %: %.c
 	$(CC) $(CCFLAGS) $(CFLAGS) $< -o $@
 
-init_env/init_env.so init_env/init_env64.so: init_env/init_env.c
+init_env/init_env.so: init_env/init_env.c
 	$(CC) $(CCFLAGS) -fPIC -shared $(CFLAGS) $^ -o $@ $(LDLIBS)
 
 clean:


### PR DESCRIPTION
Build all guest tools for the native architecture variant instead of forcing 64/32 bits for init_env and building that one twice.  CFLAGS can be set on the command line to append custom compiler flags and e.g. force 32/64 bit builds if required.

Now with better testing :-)
