### PR TITLE
s2ecmd: Add command fork to enable/disable forking

### DIFF
--- a/guest/s2ecmd/s2ecmd.c
+++ b/guest/s2ecmd/s2ecmd.c
@@ -216,6 +216,14 @@ static void handler_exemplify(const char **args)
     }
 }
 
+static void handler_fork(const char **args)
+{
+    if (!strcmp(args[0], "disable") || !strcmp(args[0], "0")) {
+        s2e_disable_forking();
+    } else {
+        s2e_enable_forking();
+    }
+}
 
 #define COMMAND(c, args, desc) { #c, handler_##c, args, desc }
 
@@ -226,6 +234,7 @@ static cmd_t s_commands[] = {
     COMMAND(symbwrite, 1, "Write n symbolic bytes to stdout"),
     COMMAND(symbfile, 1, "Makes the specified file concolic. The file should be stored in a ramdisk."),
     COMMAND(exemplify, 0, "Read from stdin and write an example to stdout"),
+    COMMAND(fork, 1, "Enable/disable forking"),
     { NULL, NULL, 0, NULL }
 };
 


### PR DESCRIPTION
Add command fork to enable/disable forking by using s2e_enable_forking() and s2e_disable_forking()

Signed-off-by: Lance Chen cyen0312@gmail.com
