### PR TITLE
Fix LLVM implementation of TCG op_div2

### DIFF
--- a/qemu/tcg/tcg-llvm.cpp
+++ b/qemu/tcg/tcg-llvm.cpp
@@ -1065,10 +1065,19 @@ int TCGLLVMContextPrivate::generateOperation(int opc, const TCGArg *args)
         v = m_builder.CreateOr(v,                                   \
                 m_builder.CreateZExt(                               \
                     getValue(args[2]), intType(bits*2)));           \
-        setValue(args[0], m_builder.Create ## signE ## Div(         \
-                v, getValue(args[4])));                             \
-        setValue(args[1], m_builder.Create ## signE ## Rem(         \
-                v, getValue(args[4])));                             \
+        setValue(args[0], m_builder.CreateTrunc(                    \
+                m_builder.Create ## signE ## Div(                   \
+                    v, m_builder.CreateZExt(                        \
+                        getValue(args[4]), intType(bits*2))         \
+                    ),                                              \
+                    intType(bits)));                                \
+        setValue(args[1], m_builder.CreateTrunc(                    \
+                m_builder.Create ## signE ## Rem(                   \
+                    v, m_builder.CreateZExt(                        \
+                        getValue(args[4]), intType(bits*2))         \
+                    ),                                              \
+                intType(bits)));                                    \
+
         break;
 
 #define __ARITH_OP_ROT(opc_name, op1, op2, bits)                    \
@@ -1109,7 +1118,7 @@ int TCGLLVMContextPrivate::generateOperation(int opc, const TCGArg *args)
     __ARITH_OP(INDEX_op_sub_i32, Sub, 32)
     __ARITH_OP(INDEX_op_mul_i32, Mul, 32)
 
-#ifdef TCG_TARGET_HAS_div_i32
+#if TCG_TARGET_HAS_div_i32
     __ARITH_OP(INDEX_op_div_i32,  SDiv, 32)
     __ARITH_OP(INDEX_op_divu_i32, UDiv, 32)
     __ARITH_OP(INDEX_op_rem_i32,  SRem, 32)
@@ -1141,7 +1150,7 @@ int TCGLLVMContextPrivate::generateOperation(int opc, const TCGArg *args)
     __ARITH_OP(INDEX_op_sub_i64, Sub, 64)
     __ARITH_OP(INDEX_op_mul_i64, Mul, 64)
 
-#ifdef TCG_TARGET_HAS_div_i64
+#if TCG_TARGET_HAS_div_i64
     __ARITH_OP(INDEX_op_div_i64,  SDiv, 64)
     __ARITH_OP(INDEX_op_divu_i64, UDiv, 64)
     __ARITH_OP(INDEX_op_rem_i64,  SRem, 64)


### PR DESCRIPTION
The LLVM code implementing `op_div2` and `op_divu2` was broken: the dividend was `bits*2` wide but the divisor was only `bits` wide. This fixes the problem by extending the divisor and then truncating the quotient.

In addition, an incorrect use of `#ifdef TCG_TARGET_HAS_div_i32` was fixed (`TCG_TARGET_HAS_div_i32` is always defined but may be 0 or 1).
