### PR TITLE
Tweaks for 14.04 compatibility. Had to disable libfdt in qemu.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,11 @@ stamps/%-make:
 	$(MAKE) -C $* $(BUILD_OPTS)
 	touch $@
 
-
+# On Ubuntu 14.04, c++config.h is located in a platform-specific path
+ifeq (,$(wildcard /usr/include/x86_64-linux-gnu/c++/4.8/c++config.h))
+ export CPLUS_INCLUDE_PATH=/usr/include:/usr/include/x86_64-linux-gnu:/usr/include/x86_64-linux-gnu/c++/4.8
+ export C_INCLUDE_PATH=/usr/include:/usr/include/x86_64-linux-gnu
+endif
 
 #############
 # Downloads #
@@ -176,8 +180,7 @@ endif
 stamps/stp-make stamps/stp-asan-make: ALWAYS
 
 STP_CONFIGURE_FLAGS = --with-prefix=$(S2EBUILD)/stp --with-fpic \
-                      --with-g++=$(CLANG_CXX) --with-gcc=$(CLANG_CC) \
-                      --with-cryptominisat2
+                      --with-g++=$(CLANG_CXX) --with-gcc=$(CLANG_CC)
 
 stamps/stp-configure: stamps/llvm-native-make
 stamps/stp-configure: CONFIGURE_COMMAND = scripts/configure $(STP_CONFIGURE_FLAGS)
@@ -274,6 +277,8 @@ QEMU_COMMON_FLAGS = --prefix=$(S2EBUILD)/opt\
                     --enable-llvm \
                     --enable-s2e \
                     --with-pkgversion=S2E \
+                    --disable-virtfs \
+                    --disable-fdt \
                     $(EXTRA_QEMU_FLAGS)
 
 QEMU_CONFIGURE_FLAGS = --with-stp=$(S2EBUILD)/stp \

--- a/docs/BuildingS2E.html
+++ b/docs/BuildingS2E.html
@@ -30,18 +30,20 @@ $ sudo apt-get install build-essential
 $ sudo apt-get install subversion
 $ sudo apt-get install git
 $ sudo apt-get install gettext
-$ sudo apt-get install liblua5.1-dev
+$ sudo apt-get install liblua5.1-0-dev
 $ sudo apt-get install libsdl1.2-dev
 $ sudo apt-get install libsigc++-2.0-dev
 $ sudo apt-get install binutils-dev
 $ sudo apt-get install python-docutils
 $ sudo apt-get install python-pygments
 $ sudo apt-get install nasm
+$ sudo apt-get install libiberty-dev
+$ sudo apt-get install libc6-dev-i386
 </pre>
 <p>The following commands ask <tt class="docutils literal"><span class="pre">apt-get</span></tt> to install build dependencies for llvm-3.0
 and qemu.</p>
 <pre class="literal-block">
-$ sudo apt-get build-dep llvm-3.0
+$ sudo apt-get build-dep llvm-3.3
 $ sudo apt-get build-dep qemu
 </pre>
 </div>

--- a/docs/BuildingS2E.rst
+++ b/docs/BuildingS2E.rst
@@ -16,18 +16,20 @@ Required Packages
     $ sudo apt-get install subversion
     $ sudo apt-get install git
     $ sudo apt-get install gettext
-    $ sudo apt-get install liblua5.1-dev
+    $ sudo apt-get install liblua5.1-0-dev
     $ sudo apt-get install libsdl1.2-dev
     $ sudo apt-get install libsigc++-2.0-dev
     $ sudo apt-get install binutils-dev
     $ sudo apt-get install python-docutils
     $ sudo apt-get install python-pygments
     $ sudo apt-get install nasm
+    $ sudo apt-get install libiberty-dev
+    $ sudo apt-get install libc6-dev-i386
 
 The following commands ask ``apt-get`` to install build dependencies for llvm-3.0
 and qemu. ::
 
-    $ sudo apt-get build-dep llvm-3.0
+    $ sudo apt-get build-dep llvm-3.3
     $ sudo apt-get build-dep qemu
 
 Checking out S2E

--- a/qemu/s2e/Synchronization.cpp
+++ b/qemu/s2e/Synchronization.cpp
@@ -45,6 +45,7 @@
 #include <fcntl.h>
 #include <iostream>
 #include <stdlib.h>
+#include <unistd.h>
 #endif
 
 #ifdef CONFIG_DARWIN

--- a/stp/src/main/Makefile
+++ b/stp/src/main/Makefile
@@ -18,7 +18,7 @@ clean:
 # Use svnversion to output the global revision number.
 versionString.stamp: FORCE
 	@SVNVERSION=`svnversion -c $(TOP)`; \
-	if [[ ! -e $@ || "x`cat $@ 2> /dev/null`" != "x$$SVNVERSION" ]]; then \
+	if [ x`cat $@ 2> /dev/null` != x"$$SVNVERSION" ]; then\
 		echo $$SVNVERSION > $@; \
 	fi
 

--- a/stp/src/parser/cvc.y
+++ b/stp/src/parser/cvc.y
@@ -22,7 +22,6 @@
 #define YYMAXDEPTH 1048576000
 #define YYERROR_VERBOSE 1
 #define YY_EXIT_FAILURE -1
-#define YYPARSE_PARAM AssertsQuery
   
   extern int cvclex(void);
   extern char* yytext;
@@ -33,7 +32,13 @@
     return YY_EXIT_FAILURE;
   };
   
+  int yyerror(void*, const char *s) {
+    return yyerror(s);
+  };
+
   %}
+
+%parse-param {void* AssertsQuery}
 
 %union {
 

--- a/stp/src/parser/smt.y
+++ b/stp/src/parser/smt.y
@@ -55,13 +55,18 @@
     return 1;
   }
 
+  int yyerror(void*, const char *s) {
+    return yyerror(s);
+  }
+
   ASTNode query;
 #define YYLTYPE_IS_TRIVIAL 1
 #define YYMAXDEPTH 104857600
 #define YYERROR_VERBOSE 1
 #define YY_EXIT_FAILURE -1
-#define YYPARSE_PARAM AssertsQuery
   %}
+
+%parse-param {void* AssertsQuery}
 
 %union {  
   // FIXME: Why is this not an UNSIGNED int?

--- a/stp/src/parser/smt2.y
+++ b/stp/src/parser/smt2.y
@@ -65,6 +65,10 @@
     return 1;
   }
 
+  int yyerror(void*, const char*s) {
+    return yyerror(s);
+  }
+
   ASTNode querysmt2;
   vector<ASTVec> assertionsSMT2;
     
@@ -72,8 +76,9 @@
 #define YYMAXDEPTH 104857600
 #define YYERROR_VERBOSE 1
 #define YY_EXIT_FAILURE -1
-#define YYPARSE_PARAM AssertsQuery
   %}
+
+%parse-param {void* AssertsQuery}
 
 %union {  
   unsigned uintval;                  /* for numerals in types. */


### PR DESCRIPTION
It's possible to fix the libfdt issue without disabling it, by removing libfdt_env.h from qemu/ (the file is already in /usr/include/ in Ubuntu 14.04). Newer versions of qemu apparently fixed the issue.
