### PR TITLE
Restoring previous iostream flags on output stream

### DIFF
--- a/qemu/s2e/Utils.h
+++ b/qemu/s2e/Utils.h
@@ -66,7 +66,9 @@ inline llvm::raw_ostream& operator<<(llvm::raw_ostream& out, const hexval& h)
 
 inline std::ostream& operator<<(std::ostream& out, const hexval& h)
 {
-    out << std::hex << (h.value);
+    std::ios::fmtflags f(out.flags());
+    out << "0x" << std::hex << (h.value);
+    out.flags(f);
     return out;
 }
 


### PR DESCRIPTION
Current implementation sets std::hex flag on output stream, this patch restores previous output stream flag upon exiting. 
