### PR TITLE
Add fuzzing test capability to S2E as FuzzyS2E

### DIFF
--- a/S2E-AUTHORS
+++ b/S2E-AUTHORS
@@ -26,4 +26,4 @@ Alexandre Gouraud <alexandre.gouraud@enst-bretagne.fr>
 Sriram Subramanian <srirams@cs.wisc.edu>
 Swaminathan Sundararaman <swami@cs.wisc.edu>
 Vlad Georgescu <vgeorgescu@gmail.com>
-
+Zhang Bin <binzhang08d@gmail.com>

--- a/docs/Plugins/FuzzyS2E.html
+++ b/docs/Plugins/FuzzyS2E.html
@@ -19,9 +19,10 @@
 <li><a class="reference internal" href="#required-plugins" id="id2">Required Plugins</a></li>
 <li><a class="reference internal" href="#autoshfilegenerator" id="id3">AutoShFileGenerator</a></li>
 <li><a class="reference internal" href="#fuzzysearcher" id="id4">FuzzySearcher</a></li>
-<li><a class="reference internal" href="#forkcontroller" id="id5">ForkController</a></li>
-<li><a class="reference internal" href="#a-sample-complete-configure-file" id="id6">A Sample Complete Configure File</a></li>
-<li><a class="reference internal" href="#start-testing-a-binary-software" id="id7">Start Testing a binary software</a></li>
+<li><a class="reference internal" href="#loopfuzzer" id="id5">LoopFuzzer</a></li>
+<li><a class="reference internal" href="#forkcontroller" id="id6">ForkController</a></li>
+<li><a class="reference internal" href="#a-sample-complete-configure-file" id="id7">A Sample Complete Configure File</a></li>
+<li><a class="reference internal" href="#start-testing-a-binary-software" id="id8">Start Testing a binary software</a></li>
 </ul>
 </div>
 <div class="section" id="what-is-fuzzys2e">
@@ -45,14 +46,15 @@ shown in another documentation soon.</p>
 <div class="section" id="required-plugins">
 <h1>Required Plugins</h1>
 <pre class="literal-block">
-BaseInstructions
-HostFiles
-RawMonitor
-ModuleExecutionDetector
-CodeSelector
-AutoShFileGenerator
-FuzzySearcher
-ForkController
+    BaseInstructions
+    HostFiles
+    RawMonitor
+    ModuleExecutionDetector
+    CodeSelector
+    AutoShFileGenerator
+    FuzzySearcher
+LoopFuzzer
+    ForkController
 </pre>
 <p>&quot;BaseInstructions&quot;, &quot;HostFiles&quot;, &quot;RawMonitor&quot;, &quot;ModuleExecutionDetector&quot;, and &quot;CodeSelector&quot; can be found in other documentation.</p>
 <p>Let see the detail configuration of the last three plug-in, i.e &quot;AutoShFileGenerator&quot;, &quot;FuzzySearcher&quot; and &quot;ForkController&quot;.</p>
@@ -107,6 +109,11 @@ debugVerbose = false,
 <p>“MaxLoops” specifies the stop condition, and we currently stop the testing procedure when it reaches to maximum iteration numbers.</p>
 <p>&quot;debugVerbose&quot; can be use to output more detail information when set to be true.</p>
 </div>
+<div class="section" id="loopfuzzer">
+<h1>LoopFuzzer</h1>
+<p>LoopFuzzer is inherited from FuzzySearcher, and it is used to reduce the test scale. The mechanism is that when we get stuck in a symbolic value controlled loop, LoopFuzzer will disable forking in this loop and generate a testcase for this loop, then LoopFuzzer continues forking when we get out from this loop. Notethat the generated testcase will be uploaded to AFL as what does in FuzzySearcher.</p>
+<p>LoopFuzzer's configuration is identical to LoopFuzzer, but they have different functions.</p>
+</div>
 <div class="section" id="forkcontroller">
 <h1>ForkController</h1>
 <p>S2E can control the fork in several levels of testing grain, like
@@ -118,8 +125,22 @@ follows.:</p>
 forkRanges ={
    r01 = {0x8048000, 0x8049000},
 },
+mainModule=&quot;app&quot;,
+loopfilename=&quot;/host/path/to/loopsfile&quot;,
 </pre>
 <p>“forkRanges” infers to the code regions that you want FuzzyS2E to fork in.</p>
+<p>“mainModule” infers to our target binary name.</p>
+<p>“loopfilename” infers to the loop file which is generated from static analysis in host OS.</p>
+<p>NOTE:</p>
+<p>Static analysis component is now implemented based on <a class="reference external" href="https://github.com/programa-stic/barf-project/blob/master/documentation/papers/barf.pdf">barf: A multiplatform open source Binary Analysis and Reverse engineering Framework</a> as a plug-in of IDA pro.</p>
+<p>The loop file contains all the start addresses (in decimal) of basic blocks of a loop in a line, the sample file is listed below.</p>
+<div class="highlight"><pre><span class="c1">-- a sample loopfile</span>
+<span class="mi">134513930</span> <span class="mi">134513920</span> <span class="mi">134513930</span> <span class="mi">134513940</span> <span class="c1">-- loop0</span>
+<span class="mi">134513920</span> <span class="mi">134513930</span> <span class="c1">-- loop1</span>
+<span class="mi">134514174</span> <span class="mi">134514166</span> <span class="c1">-- loop2</span>
+<span class="mi">134514664</span> <span class="mi">134514690</span> <span class="c1">-- loop3</span>
+<span class="mi">134514643</span> <span class="mi">134514619</span> <span class="mi">134514651</span> <span class="mi">134514608</span> <span class="c1">--loop4</span>
+</pre></div>
 </div>
 <div class="section" id="a-sample-complete-configure-file">
 <h1>A Sample Complete Configure File</h1>
@@ -167,6 +188,8 @@ forkRanges ={
    <span class="n">forkRanges</span> <span class="o">=</span><span class="p">{</span>
       <span class="n">r01</span> <span class="o">=</span> <span class="p">{</span><span class="mh">0x8048000</span><span class="p">,</span> <span class="mh">0x8049000</span><span class="p">},</span>
    <span class="p">},</span>
+   <span class="n">mainModule</span><span class="o">=</span><span class="s2">&quot;</span><span class="s">app&quot;</span><span class="p">,</span>
+   <span class="n">loopfilename</span><span class="o">=</span><span class="s2">&quot;</span><span class="s">/host/path/to/loopsfile&quot;</span>
 <span class="p">}</span>
 
 <span class="c1">-- Core search plugin to schedule states and communication with AFL fuzzer</span>

--- a/docs/Plugins/FuzzyS2E.html
+++ b/docs/Plugins/FuzzyS2E.html
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="Docutils 0.11: http://docutils.sourceforge.net/" />
+<title>FuzzyS2E</title>
+<link rel="stylesheet" href="../s2e.css" type="text/css" />
+</head>
+<body>
+<div class="document" id="fuzzys2e">
+<h1 class="title">FuzzyS2E</h1>
+
+<p>In this documentation, we will show how to use FuzzyS2E to find bugs in software. Specifically, this documentation focuses on Linux software.</p>
+<div class="contents topic" id="contents">
+<p class="topic-title first">Contents</p>
+<ul class="simple">
+<li><a class="reference internal" href="#what-is-fuzzys2e" id="id1">What is FuzzyS2E</a></li>
+<li><a class="reference internal" href="#required-plugins" id="id2">Required Plugins</a></li>
+<li><a class="reference internal" href="#autoshfilegenerator" id="id3">AutoShFileGenerator</a></li>
+<li><a class="reference internal" href="#fuzzysearcher" id="id4">FuzzySearcher</a></li>
+<li><a class="reference internal" href="#forkcontroller" id="id5">ForkController</a></li>
+<li><a class="reference internal" href="#a-sample-complete-configure-file" id="id6">A Sample Complete Configure File</a></li>
+<li><a class="reference internal" href="#start-testing-a-binary-software" id="id7">Start Testing a binary software</a></li>
+</ul>
+</div>
+<div class="section" id="what-is-fuzzys2e">
+<h1>What is FuzzyS2E</h1>
+<p>S2E is built on top of symbolic execution and even though it has solved the path
+explosion problem to a large extent, but because the complex constraint solving
+problem is still not well handled in its solvers, like STP, so it may get stuck in some
+cases. While fuzzing test is a great way to find GREAT seed paths, so FuzzyS2E
+utilizes this advantage to help S2E avoid this problem, and in return, fuzzing test can
+be helped with the output of S2E to promote its path discovering ability.
+FuzzyS2E is built on top of S2E and AFL, which is an open-sourced fuzzing test
+system. FuzzyS2E tries to exchange concrete testcases between S2E and AFL, when
+we start the testing procedure, S2E first starts its concolic testing procedure with a
+random concrete input testcase. Then as the testing goes on, S2E can generate several
+testcases for different paths, which can be used as the input of AFL, and then AFL
+starts its fuzzing test and generates more testcases based on these initial inputs. Note
+that during the whole procedure, AFL can dynamically exchange concrete testcases
+with S2E so that they can help each other. The detail technical documentation will be
+shown in another documentation soon.</p>
+</div>
+<div class="section" id="required-plugins">
+<h1>Required Plugins</h1>
+<pre class="literal-block">
+BaseInstructions
+HostFiles
+RawMonitor
+ModuleExecutionDetector
+CodeSelector
+AutoShFileGenerator
+FuzzySearcher
+ForkController
+</pre>
+<p>&quot;BaseInstructions&quot;, &quot;HostFiles&quot;, &quot;RawMonitor&quot;, &quot;ModuleExecutionDetector&quot;, and &quot;CodeSelector&quot; can be found in other documentation.</p>
+<p>Let see the detail configuration of the last three plug-in, i.e &quot;AutoShFileGenerator&quot;, &quot;FuzzySearcher&quot; and &quot;ForkController&quot;.</p>
+</div>
+<div class="section" id="autoshfilegenerator">
+<h1>AutoShFileGenerator</h1>
+<p>AutoShFileGenerator tries to generate a shell script so that the testing and its iteration
+can start automatically to avoid tedious manual work. An example configure file of
+AutoShFileGenerator is shown as followss:</p>
+<pre class="literal-block">
+command_str = '#!/bin/bash \n /guest/path/to/s2eget aa.txt &amp;&amp; cp aa.txt /tmp/aa.txt &amp;&amp; /guest/path/to/s2ecmd symbfile /tmp/aa.txt &amp;&amp; LD_PRELOAD=/guest/path/to/init_env.so /guest/path/to/app --select-process-code /tmp/aa.txt',
+command_file = &quot;/host/path/to/autostart.sh&quot;,
+</pre>
+<p>“command_str” infers the detail content of shell script. In order to exchange concrete
+testcase with AFL, which means FuzzyS2E has to exchange files with host OS
+dynamically during the testing, you have to get the testcase (“ /guest/path/to/s2eget
+aa.txt ”) and copy it to a ramdisk (“ cp aa.txt /tmp/aa.txt ”) and then mark the testcase as
+symbolic (“ /guest/path/to/s2ecmd symbfile /tmp/aa.txt ”) and finally start the binary target
+code (“ LD_PRELOAD=/guest/path/to/init_env.so /guest/path/to/app --select-process-code
+/tmp/aa.txt ”). All this has been written to a shell script file in host as
+“command_file”(“ /host/path/to/autostart.sh ”).</p>
+</div>
+<div class="section" id="fuzzysearcher">
+<h1>FuzzySearcher</h1>
+<p>FuzzySearcher is the core search plugin for FuzzyS2E, it tries to schedule all the
+execution states and communicate with AFL. An example configure of FuzzySearcher
+is shown as follows.:</p>
+<pre class="literal-block">
+symbolicfilename = &quot;aa.txt&quot;,
+inicasepool = &quot;/host/path/to/initialtestcasepool&quot;,
+curcasepool = &quot;/host/path/to/curtmp&quot;,
+aflRoot=&quot;/host/path/to/afl-1.96b&quot;,
+aflOutput=&quot;/host/path/to/afloutput&quot;,
+aflBinaryMode=true,
+aflAppArgs=&quot;/host/path/to/app &#64;&#64;&quot;,
+mainModule=&quot;app&quot;;
+autosendkey_enter = true,
+autosendkey_interval = 10,
+MaxLoops = 50,
+debugVerbose = false,
+</pre>
+<p>“symbolicfilename” infers to the testcase name in AutoShFileGenerator.</p>
+<p>“inicasepool” infers to the directory which stores the initial testcase for S2E in host OS.</p>
+<p>“curcasepool” infers to the directory which stores the current testcase for S2E in host OS.</p>
+<p>“aflRoot” infers to the root directory of AFL in host OS.</p>
+<p>“aflOutput” infers to the output directory of AFL in host OS.</p>
+<p>“aflBinaryMode” represents whether we want to test binary-only software, please set this always to be TRUE, because we focus on binary software testing.</p>
+<p>“aflAppArgs” infers to the whole command line arguments for target binary and you should replace the input file argument with “&#64;&#64;”, as documented in AFL.</p>
+<p>“mainModule” infers to our target binary name.</p>
+<p>“autosendkey_enter” will automatically send “enter” to guest OS if set to be TRUE, otherwise, you have to send this key manually before each iteration.</p>
+<p>“autosendkey_interval” infers to the time interval before we send “enter” to guest OS.</p>
+<p>“MaxLoops” specifies the stop condition, and we currently stop the testing procedure when it reaches to maximum iteration numbers.</p>
+<p>&quot;debugVerbose&quot; can be use to output more detail information when set to be true.</p>
+</div>
+<div class="section" id="forkcontroller">
+<h1>ForkController</h1>
+<p>S2E can control the fork in several levels of testing grain, like
+“select-process-code(target binary only)”, “select-process-user(target process in user
+mode)”, but ForkController can give a more fine grained fork control, it can restrict
+the fork in a code region, An example configure of ForkController is shown as
+follows.:</p>
+<pre class="literal-block">
+forkRanges ={
+   r01 = {0x8048000, 0x8049000},
+},
+</pre>
+<p>“forkRanges” infers to the code regions that you want FuzzyS2E to fork in.</p>
+</div>
+<div class="section" id="a-sample-complete-configure-file">
+<h1>A Sample Complete Configure File</h1>
+<div class="highlight"><pre><span class="c1">-- File: config.lua</span>
+<span class="n">s2e</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="n">kleeArgs</span> <span class="o">=</span> <span class="p">{</span>
+      <span class="s2">&quot;</span><span class="s">--use-concolic-execution=true&quot;</span><span class="p">,</span> <span class="c1">-- FuzzyS2E should be run in concolic mode</span>
+      <span class="s2">&quot;</span><span class="s">--use-dfs-search=true&quot;</span><span class="p">,</span> <span class="c1">-- It is not very important whether to specify the searcher for S2E</span>
+   <span class="p">}</span>
+<span class="p">}</span>
+
+<span class="n">plugins</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="s2">&quot;</span><span class="s">BaseInstructions&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">HostFiles&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">RawMonitor&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">ModuleExecutionDetector&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">CodeSelector&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">AutoShFileGenerator&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">FuzzySearcher&quot;</span><span class="p">,</span>
+   <span class="s2">&quot;</span><span class="s">ForkController&quot;</span><span class="p">,</span>
+<span class="p">}</span>
+
+<span class="n">pluginsConfig</span> <span class="o">=</span> <span class="p">{}</span>
+
+<span class="c1">-- Enable guest OS to communicate with host OS</span>
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">HostFiles</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="n">baseDirs</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;</span><span class="s">/path/to/host &quot;</span><span class="p">,</span> <span class="s2">&quot;</span><span class="s">/host/path to/cur&quot;</span><span class="p">}</span>
+<span class="p">}</span>
+
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">CodeSelector</span> <span class="o">=</span> <span class="p">{</span>
+<span class="p">}</span>
+
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">RawMonitor</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="n">kernelStart</span> <span class="o">=</span> <span class="mh">0xc0000000</span><span class="p">,</span>
+<span class="p">}</span>
+
+<span class="c1">-- ModuleExecutionDetector can help us to incept the module load event</span>
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">ModuleExecutionDetector</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="n">trackAllModules</span><span class="o">=</span><span class="kc">false</span><span class="p">,</span>
+   <span class="n">configureAllModules</span><span class="o">=</span><span class="kc">false</span><span class="p">,</span>
+<span class="p">}</span>
+
+<span class="c1">-- Enable us to perform more fine-grained fork control</span>
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">ForkController</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="n">forkRanges</span> <span class="o">=</span><span class="p">{</span>
+      <span class="n">r01</span> <span class="o">=</span> <span class="p">{</span><span class="mh">0x8048000</span><span class="p">,</span> <span class="mh">0x8049000</span><span class="p">},</span>
+   <span class="p">},</span>
+<span class="p">}</span>
+
+<span class="c1">-- Core search plugin to schedule states and communication with AFL fuzzer</span>
+<span class="cm">--[[</span>
+<span class="cm">   *FuzzyS2E will start with a random concrete input file in &quot;inicasepool&quot; in host, and copy it to &quot;curcasepool&quot; in host and rename it as &quot;symbolicfilename&quot;.</span>
+<span class="cm">   *Then guest OS will get the &quot;AutoShFileGenerator.command_file&quot; from host and execute it, which will first mark the file with name of &quot;symbolicfilename&quot; as symbolic and start to execute &quot;mainModule&quot;. At a proper time stamp, \</span>
+<span class="cm">AFL will be started from &quot;aflRoot&quot; and its output directory is set to &quot;aflOutput&quot;, the target application auguments could be &quot;aflAppArgs&quot;, in which the input file is replaced with &quot;@@&quot;.</span>
+<span class="cm">   *Finally when FuzzyS2E executes for &quot;MaxLoops&quot; iterations, it stops both S2E and AFL.</span>
+<span class="cm">]]</span><span class="c1">--</span>
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">FuzzySearcher</span> <span class="o">=</span> <span class="p">{</span>
+   <span class="n">symbolicfilename</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="s">aa.txt&quot;</span><span class="p">,</span>
+   <span class="n">inicasepool</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="s">/host/path/to/initialtestcasepool&quot;</span><span class="p">,</span>
+   <span class="n">curcasepool</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="s">/host/path/to/curtmp&quot;</span><span class="p">,</span>
+   <span class="n">aflRoot</span><span class="o">=</span><span class="s2">&quot;</span><span class="s">/host/path/to/afl-1.96b&quot;</span><span class="p">,</span>
+   <span class="n">aflOutput</span><span class="o">=</span><span class="s2">&quot;</span><span class="s">/host/path/to/afloutput&quot;</span><span class="p">,</span>
+   <span class="n">aflBinaryMode</span><span class="o">=</span><span class="kc">true</span><span class="p">,</span>
+   <span class="n">aflAppArgs</span><span class="o">=</span><span class="s2">&quot;</span><span class="s">/host/path/to/app @@&quot;</span><span class="p">,</span>
+   <span class="n">mainModule</span><span class="o">=</span><span class="s2">&quot;</span><span class="s">app&quot;</span><span class="p">;</span>
+   <span class="n">autosendkey_enter</span> <span class="o">=</span> <span class="kc">true</span><span class="p">,</span>
+   <span class="n">autosendkey_interval</span> <span class="o">=</span> <span class="mi">10</span><span class="p">,</span>
+   <span class="n">MaxLoops</span> <span class="o">=</span> <span class="mi">50</span><span class="p">,</span>
+   <span class="n">debugVerbose</span> <span class="o">=</span> <span class="kc">false</span><span class="p">,</span>
+<span class="p">}</span>
+
+<span class="c1">-- Generate shell script for guest OS to avoid tedious manual work</span>
+<span class="n">pluginsConfig</span><span class="p">.</span><span class="n">AutoShFileGenerator</span><span class="o">=</span><span class="p">{</span>
+   <span class="n">command_str</span> <span class="o">=</span> <span class="s1">&#39;</span><span class="s">#!/bin/bash </span><span class="se">\n</span><span class="s"> /guest/path/to/s2eget aa.txt &amp;&amp; cp aa.txt /tmp/aa.txt  &amp;&amp; /guest/path/to/s2ecmd symbfile /tmp/aa.txt &amp;&amp; LD_PRELOAD=/guest/path/to/init_env.so /guest/path/to/app --select-process-code /tmp/aa.txt&#39;</span><span class="p">,</span>
+   <span class="n">command_file</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="s">/host/path/to/autostart.sh&quot;</span><span class="p">,</span>
+<span class="p">}</span>
+</pre></div>
+</div>
+<div class="section" id="start-testing-a-binary-software">
+<h1>Start Testing a binary software</h1>
+<p>As you have configured the config-file correctly and start the FuzzyS2E. Then FuzzyS2E’s guest will get this automatically generated shell script file
+(“ /host/path/to/autostart.sh ”) though HostFiles plug-in and some command line in
+guest’s shell, after that, FuzzyS2E will automatically start the testprocedure. The guest’s shell command line is show as follows.:</p>
+<pre class="literal-block">
+guest$ $GUEST-TOOLs/s2eget autostart.sh &amp;&amp; chmod +x ./autostart.sh &amp;&amp; ./autostart.sh
+</pre>
+<p>A self-contained  VM image has been put on the Internet, and you can download it and have a try.</p>
+<ul class="simple">
+<li><a class="reference external" href="https://drive.google.com/file/d/0B6yf7Wx5zFZ7a3RKU1pXTFZBZk0/view?usp=sharing">FuzzyS2E VM Image</a>.</li>
+</ul>
+<dl class="docutils">
+<dt>The user and password for fuzzys2e is:</dt>
+<dd><p class="first">For the host OS:</p>
+<pre class="literal-block">
+User: epeius
+Pass: 1234567890
+</pre>
+<p>For the guest OS:</p>
+<pre class="last literal-block">
+User: debian
+Pass: 1234567890
+</pre>
+</dd>
+</dl>
+<p>If you have any questions, please let me know&lt;<a class="reference external" href="mailto:binzh4ng&#64;hotmail.com">binzh4ng&#64;hotmail.com</a>&gt;. Thanks.</p>
+<p>Have fun with FuzzyS2E.</p>
+</div>
+</div>
+<div class="footer">
+<hr class="footer" />
+<a class="reference external" href="FuzzyS2E.rst">View document source</a>.
+
+</div>
+</body>
+</html>

--- a/docs/Plugins/FuzzyS2E.rst
+++ b/docs/Plugins/FuzzyS2E.rst
@@ -36,6 +36,7 @@ Required Plugins
 	CodeSelector
 	AutoShFileGenerator
 	FuzzySearcher
+    LoopFuzzer
 	ForkController
 
 "BaseInstructions", "HostFiles", "RawMonitor", "ModuleExecutionDetector", and "CodeSelector" can be found in other documentation.
@@ -105,6 +106,13 @@ is shown as follows.::
 
 "debugVerbose" can be use to output more detail information when set to be true.
 
+LoopFuzzer
+=============
+
+LoopFuzzer is inherited from FuzzySearcher, and it is used to reduce the test scale. The mechanism is that when we get stuck in a symbolic value controlled loop, LoopFuzzer will disable forking in this loop and generate a testcase for this loop, then LoopFuzzer continues forking when we get out from this loop. Notethat the generated testcase will be uploaded to AFL as what does in FuzzySearcher.
+
+LoopFuzzer's configuration is identical to LoopFuzzer, but they have different functions.
+
 ForkController
 ==============
 
@@ -117,8 +125,30 @@ follows.::
    forkRanges ={
       r01 = {0x8048000, 0x8049000},
    },
+   mainModule="app",
+   loopfilename="/host/path/to/loopsfile",
 
 “forkRanges” infers to the code regions that you want FuzzyS2E to fork in.
+
+“mainModule” infers to our target binary name.
+
+“loopfilename” infers to the loop file which is generated from static analysis in host OS.
+
+NOTE:
+
+Static analysis component is now implemented based on `barf: A multiplatform open source Binary Analysis and Reverse engineering Framework <https://github.com/programa-stic/barf-project/blob/master/documentation/papers/barf.pdf>`_ as a plug-in of IDA pro. 
+
+The loop file contains all the start addresses (in decimal) of basic blocks of a loop in a line, the sample file is listed below.
+
+.. code-block:: lua
+
+   -- a sample loopfile
+   134513930 134513920 134513930 134513940 -- loop0
+   134513920 134513930 -- loop1
+   134514174 134514166 -- loop2
+   134514664 134514690 -- loop3
+   134514643 134514619 134514651 134514608 --loop4
+
 
 A Sample Complete Configure File
 ================================
@@ -168,6 +198,8 @@ A Sample Complete Configure File
       forkRanges ={
          r01 = {0x8048000, 0x8049000},
       },
+      mainModule="app",
+      loopfilename="/host/path/to/loopsfile"
    }
 
    -- Core search plugin to schedule states and communication with AFL fuzzer

--- a/docs/Plugins/FuzzyS2E.rst
+++ b/docs/Plugins/FuzzyS2E.rst
@@ -1,0 +1,227 @@
+==========
+FuzzyS2E
+==========
+
+In this documentation, we will show how to use FuzzyS2E to find bugs in software. Specifically, this documentation focuses on Linux software.
+
+.. contents::
+
+What is FuzzyS2E
+=================
+S2E is built on top of symbolic execution and even though it has solved the path
+explosion problem to a large extent, but because the complex constraint solving
+problem is still not well handled in its solvers, like STP, so it may get stuck in some
+cases. While fuzzing test is a great way to find GREAT seed paths, so FuzzyS2E
+utilizes this advantage to help S2E avoid this problem, and in return, fuzzing test can
+be helped with the output of S2E to promote its path discovering ability.
+FuzzyS2E is built on top of S2E and AFL, which is an open-sourced fuzzing test
+system. FuzzyS2E tries to exchange concrete testcases between S2E and AFL, when
+we start the testing procedure, S2E first starts its concolic testing procedure with a
+random concrete input testcase. Then as the testing goes on, S2E can generate several
+testcases for different paths, which can be used as the input of AFL, and then AFL
+starts its fuzzing test and generates more testcases based on these initial inputs. Note
+that during the whole procedure, AFL can dynamically exchange concrete testcases
+with S2E so that they can help each other. The detail technical documentation will be
+shown in another documentation soon.
+
+Required Plugins
+=================
+
+::
+
+	BaseInstructions
+	HostFiles
+	RawMonitor
+	ModuleExecutionDetector
+	CodeSelector
+	AutoShFileGenerator
+	FuzzySearcher
+	ForkController
+
+"BaseInstructions", "HostFiles", "RawMonitor", "ModuleExecutionDetector", and "CodeSelector" can be found in other documentation.
+
+Let see the detail configuration of the last three plug-in, i.e "AutoShFileGenerator", "FuzzySearcher" and "ForkController".
+
+AutoShFileGenerator
+===================
+
+AutoShFileGenerator tries to generate a shell script so that the testing and its iteration
+can start automatically to avoid tedious manual work. An example configure file of
+AutoShFileGenerator is shown as followss::
+
+	command_str = '#!/bin/bash \n /guest/path/to/s2eget aa.txt && cp aa.txt /tmp/aa.txt && /guest/path/to/s2ecmd symbfile /tmp/aa.txt && LD_PRELOAD=/guest/path/to/init_env.so /guest/path/to/app --select-process-code /tmp/aa.txt',
+	command_file = "/host/path/to/autostart.sh",
+
+“command_str” infers the detail content of shell script. In order to exchange concrete
+testcase with AFL, which means FuzzyS2E has to exchange files with host OS
+dynamically during the testing, you have to get the testcase (“ /guest/path/to/s2eget
+aa.txt ”) and copy it to a ramdisk (“ cp aa.txt /tmp/aa.txt ”) and then mark the testcase as
+symbolic (“ /guest/path/to/s2ecmd symbfile /tmp/aa.txt ”) and finally start the binary target
+code (“ LD_PRELOAD=/guest/path/to/init_env.so /guest/path/to/app --select-process-code
+/tmp/aa.txt ”). All this has been written to a shell script file in host as
+“command_file”(“ /host/path/to/autostart.sh ”).
+
+FuzzySearcher
+=============
+
+FuzzySearcher is the core search plugin for FuzzyS2E, it tries to schedule all the
+execution states and communicate with AFL. An example configure of FuzzySearcher
+is shown as follows.::
+
+   symbolicfilename = "aa.txt",
+   inicasepool = "/host/path/to/initialtestcasepool",
+   curcasepool = "/host/path/to/curtmp",
+   aflRoot="/host/path/to/afl-1.96b",
+   aflOutput="/host/path/to/afloutput",
+   aflBinaryMode=true,
+   aflAppArgs="/host/path/to/app @@",
+   mainModule="app";
+   autosendkey_enter = true,
+   autosendkey_interval = 10,
+   MaxLoops = 50,
+   debugVerbose = false,
+
+“symbolicfilename” infers to the testcase name in AutoShFileGenerator.
+
+“inicasepool” infers to the directory which stores the initial testcase for S2E in host OS.
+
+“curcasepool” infers to the directory which stores the current testcase for S2E in host OS.
+
+“aflRoot” infers to the root directory of AFL in host OS.
+
+“aflOutput” infers to the output directory of AFL in host OS.
+
+“aflBinaryMode” represents whether we want to test binary-only software, please set this always to be TRUE, because we focus on binary software testing.
+
+“aflAppArgs” infers to the whole command line arguments for target binary and you should replace the input file argument with “@@”, as documented in AFL.
+
+“mainModule” infers to our target binary name.
+
+“autosendkey_enter” will automatically send “enter” to guest OS if set to be TRUE, otherwise, you have to send this key manually before each iteration.
+
+“autosendkey_interval” infers to the time interval before we send “enter” to guest OS.
+
+“MaxLoops” specifies the stop condition, and we currently stop the testing procedure when it reaches to maximum iteration numbers.
+
+"debugVerbose" can be use to output more detail information when set to be true.
+
+ForkController
+==============
+
+S2E can control the fork in several levels of testing grain, like
+“select-process-code(target binary only)”, “select-process-user(target process in user
+mode)”, but ForkController can give a more fine grained fork control, it can restrict
+the fork in a code region, An example configure of ForkController is shown as
+follows.::
+
+   forkRanges ={
+      r01 = {0x8048000, 0x8049000},
+   },
+
+“forkRanges” infers to the code regions that you want FuzzyS2E to fork in.
+
+A Sample Complete Configure File
+================================
+.. code-block:: lua
+
+   -- File: config.lua
+   s2e = {
+      kleeArgs = {
+         "--use-concolic-execution=true", -- FuzzyS2E should be run in concolic mode
+         "--use-dfs-search=true", -- It is not very important whether to specify the searcher for S2E
+      }
+   }
+
+   plugins = {
+      "BaseInstructions",
+      "HostFiles",
+      "RawMonitor",
+      "ModuleExecutionDetector",
+      "CodeSelector",
+      "AutoShFileGenerator",
+      "FuzzySearcher",
+      "ForkController",
+   }
+
+   pluginsConfig = {}
+
+   -- Enable guest OS to communicate with host OS 
+   pluginsConfig.HostFiles = {
+      baseDirs = {"/path/to/host ", "/host/path to/cur"}
+   }
+
+   pluginsConfig.CodeSelector = {
+   }
+
+   pluginsConfig.RawMonitor = {
+      kernelStart = 0xc0000000,
+   }
+
+   -- ModuleExecutionDetector can help us to incept the module load event
+   pluginsConfig.ModuleExecutionDetector = {
+      trackAllModules=false,
+      configureAllModules=false,
+   }
+
+   -- Enable us to perform more fine-grained fork control
+   pluginsConfig.ForkController = {
+      forkRanges ={
+         r01 = {0x8048000, 0x8049000},
+      },
+   }
+
+   -- Core search plugin to schedule states and communication with AFL fuzzer
+   --[[
+      *FuzzyS2E will start with a random concrete input file in "inicasepool" in host, and copy it to "curcasepool" in host and rename it as "symbolicfilename". 
+      *Then guest OS will get the "AutoShFileGenerator.command_file" from host and execute it, which will first mark the file with name of "symbolicfilename" as symbolic and start to execute "mainModule". At a proper time stamp, \
+   AFL will be started from "aflRoot" and its output directory is set to "aflOutput", the target application auguments could be "aflAppArgs", in which the input file is replaced with "@@". 
+      *Finally when FuzzyS2E executes for "MaxLoops" iterations, it stops both S2E and AFL.
+   ]]--
+   pluginsConfig.FuzzySearcher = {
+      symbolicfilename = "aa.txt",
+      inicasepool = "/host/path/to/initialtestcasepool",
+      curcasepool = "/host/path/to/curtmp",
+      aflRoot="/host/path/to/afl-1.96b",
+      aflOutput="/host/path/to/afloutput",
+      aflBinaryMode=true,
+      aflAppArgs="/host/path/to/app @@",
+      mainModule="app";
+      autosendkey_enter = true,
+      autosendkey_interval = 10,
+      MaxLoops = 50,
+      debugVerbose = false,
+   }
+
+   -- Generate shell script for guest OS to avoid tedious manual work
+   pluginsConfig.AutoShFileGenerator={
+      command_str = '#!/bin/bash \n /guest/path/to/s2eget aa.txt && cp aa.txt /tmp/aa.txt  && /guest/path/to/s2ecmd symbfile /tmp/aa.txt && LD_PRELOAD=/guest/path/to/init_env.so /guest/path/to/app --select-process-code /tmp/aa.txt',
+      command_file = "/host/path/to/autostart.sh",
+   }
+
+Start Testing a binary software
+================================
+As you have configured the config-file correctly and start the FuzzyS2E. Then FuzzyS2E’s guest will get this automatically generated shell script file
+(“ /host/path/to/autostart.sh ”) though HostFiles plug-in and some command line in
+guest’s shell, after that, FuzzyS2E will automatically start the testprocedure. The guest’s shell command line is show as follows.::
+
+   guest$ $GUEST-TOOLs/s2eget autostart.sh && chmod +x ./autostart.sh && ./autostart.sh
+
+A self-contained  VM image has been put on the Internet, and you can download it and have a try.
+
+* `FuzzyS2E VM Image
+  <https://drive.google.com/file/d/0B6yf7Wx5zFZ7a3RKU1pXTFZBZk0/view?usp=sharing>`_.
+
+The user and password for fuzzys2e is:
+   For the host OS::
+
+      User: epeius
+      Pass: 1234567890
+
+   For the guest OS::
+
+      User: debian
+      Pass: 1234567890
+
+If you have any questions, please let me know<binzh4ng@hotmail.com>. Thanks.
+
+Have fun with FuzzyS2E.

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,10 +21,11 @@
 <li><a class="reference internal" href="#selection-plugins" id="id6">Selection Plugins</a></li>
 <li><a class="reference internal" href="#analysis-plugins" id="id7">Analysis Plugins</a></li>
 <li><a class="reference internal" href="#miscellaneous-plugins" id="id8">Miscellaneous Plugins</a></li>
+<li><a class="reference internal" href="#fuzzys2e-plugins" id="id9">FuzzyS2E Plugins</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#s2e-development" id="id9">S²E Development</a></li>
-<li><a class="reference internal" href="#s2e-publications" id="id10">S²E Publications</a></li>
+<li><a class="reference internal" href="#s2e-development" id="id10">S²E Development</a></li>
+<li><a class="reference internal" href="#s2e-publications" id="id11">S²E Publications</a></li>
 </ul>
 </div>
 <p>Do not forget the <a class="reference external" href="FAQ.html">FAQ</a> if you have questions.</p>
@@ -121,6 +122,13 @@ how to combine these tracers.</p>
 <ul class="simple">
 <li><a class="reference external" href="Plugins/FunctionMonitor.html">FunctionMonitor</a> provides client plugins with events triggered when the guest code invokes specified functions.</li>
 <li><a class="reference external" href="UsingS2EGet.html">HostFiles</a> allows to quickly upload files to the guest.</li>
+</ul>
+</div>
+<div class="section" id="fuzzys2e-plugins">
+<h2>FuzzyS2E Plugins</h2>
+<p>These plugins allow you to exchange concrete testcases and runtime information with AFL fuzzer</p>
+<ul class="simple">
+<li><a class="reference external" href="Plugins/FuzzyS2E.html">FuzzyS2E</a></li>
 </ul>
 </div>
 </div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,6 +102,13 @@ Miscellaneous Plugins
 * `FunctionMonitor <Plugins/FunctionMonitor.rst>`_ provides client plugins with events triggered when the guest code invokes specified functions.
 * `HostFiles <UsingS2EGet.rst>`_ allows to quickly upload files to the guest.
 
+FuzzyS2E Plugins
+---------------------
+
+These plugins allow you to exchange concrete testcases and runtime information with AFL fuzzer
+
+* `FuzzyS2E <Plugins/FuzzyS2E.rst>`_
+
 S²E Development
 ===============
 

--- a/klee/include/klee/ExecutionState.h
+++ b/klee/include/klee/ExecutionState.h
@@ -64,7 +64,11 @@ struct StackFrame {
 
 class ExecutionState {
   friend class AddressSpace;
-
+  //epeius start
+public:
+  bool  m_is_carry_on_state; //
+  bool  m_silently_concretized;// whether this state is a silent concretized state<KLEE EROOR>
+  //epeius end
 public:
   typedef std::vector<StackFrame> stack_ty;
 

--- a/klee/lib/Core/ExecutionState.cpp
+++ b/klee/lib/Core/ExecutionState.cpp
@@ -64,6 +64,8 @@ StackFrame::~StackFrame() {
 ExecutionState::ExecutionState(KFunction *kf) 
   : fakeState(false),
     underConstrained(false),
+    m_is_carry_on_state(false),//epeius
+    m_silently_concretized(false),//epeius
     depth(0),
     pc(kf->instructions),
     prevPC(pc),
@@ -82,6 +84,8 @@ ExecutionState::ExecutionState(KFunction *kf)
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions) 
   : fakeState(true),
     underConstrained(false),
+    m_is_carry_on_state(false),//epeius
+    m_silently_concretized(false),//epeius
     constraints(assumptions),
     queryCost(0.),
     addressSpace(this),

--- a/klee/lib/Core/Executor.cpp
+++ b/klee/lib/Core/Executor.cpp
@@ -1363,7 +1363,7 @@ Executor::toConstant(ExecutionState &state,
   os << "silently concretizing (reason: " << reason << ") expression " << e 
      << " to value " << value 
      << " (" << (*(state.pc)).info->file << ":" << (*(state.pc)).info->line << ")";
-      
+  state.m_silently_concretized = true;//epeius. We add here to avoid stuck
   klee_warning_external(reason, "%s", os.str().c_str());
 
   addConstraint(state, EqExpr::create(e, value));

--- a/qemu/Makefile.target
+++ b/qemu/Makefile.target
@@ -510,6 +510,10 @@ s2eobj-y += s2e/Plugins/HostFiles.o
 s2eobj-y += s2e/Plugins/LibraryCallMonitor.o
 s2eobj-y += s2e/Plugins/Searchers/MaxTbSearcher.o
 
+#epeius plug-ins
+s2eobj-y += s2e/Plugins/AFLControllers/AutoShFileGenerator.o
+#epeius end
+
 #sqlite database is deprecated now
 #s2eobj-y += s2e/sqlite3.o
 #s2eobj-y += s2e/Database.o

--- a/qemu/Makefile.target
+++ b/qemu/Makefile.target
@@ -513,6 +513,7 @@ s2eobj-y += s2e/Plugins/Searchers/MaxTbSearcher.o
 #epeius plug-ins
 s2eobj-y += s2e/Plugins/AFLControllers/AutoShFileGenerator.o
 s2eobj-y += s2e/Plugins/AFLControllers/ForkController.o
+s2eobj-y += s2e/Plugins/AFLControllers/FuzzySearcher.o #Core plug-in so that we can exchange sth. with AFL
 #epeius end
 
 #sqlite database is deprecated now

--- a/qemu/Makefile.target
+++ b/qemu/Makefile.target
@@ -514,6 +514,7 @@ s2eobj-y += s2e/Plugins/Searchers/MaxTbSearcher.o
 s2eobj-y += s2e/Plugins/AFLControllers/AutoShFileGenerator.o
 s2eobj-y += s2e/Plugins/AFLControllers/ForkController.o
 s2eobj-y += s2e/Plugins/AFLControllers/FuzzySearcher.o #Core plug-in so that we can exchange sth. with AFL
+s2eobj-y += s2e/Plugins/AFLControllers/LoopFuzzer.o
 #epeius end
 
 #sqlite database is deprecated now

--- a/qemu/Makefile.target
+++ b/qemu/Makefile.target
@@ -512,6 +512,7 @@ s2eobj-y += s2e/Plugins/Searchers/MaxTbSearcher.o
 
 #epeius plug-ins
 s2eobj-y += s2e/Plugins/AFLControllers/AutoShFileGenerator.o
+s2eobj-y += s2e/Plugins/AFLControllers/ForkController.o
 #epeius end
 
 #sqlite database is deprecated now

--- a/qemu/configure
+++ b/qemu/configure
@@ -3822,7 +3822,7 @@ symlink $source_path/Makefile.target $target_dir/Makefile
 if test "$target_s2e" = "yes"; then
   S2E_DIRS="s2e s2e/Interceptor s2e/Plugins s2e/Plugins/WindowsInterceptor s2e/Configuration s2e/Signals"
   S2E_DIRS="$S2E_DIRS s2e/Plugins/DataSelectors s2e/Plugins/ExecutionTracers"
-  S2E_DIRS="$S2E_DIRS s2e/Plugins/WindowsApi s2e/Plugins/Searchers"
+  S2E_DIRS="$S2E_DIRS s2e/Plugins/WindowsApi s2e/Plugins/Searchers s2e/Plugins/AFLControllers"
   for dir in $S2E_DIRS ; do
     mkdir -p $target_dir/$dir
   done

--- a/qemu/cpu-all.h
+++ b/qemu/cpu-all.h
@@ -295,6 +295,8 @@ static inline int _s2e_check_concrete(void *objectState,
 #if 1
     if(unlikely(*(uint8_t***) objectState)) {
         uint8_t* bits = **(uint8_t***) objectState;
+        if(!bits)
+        	return 0;//FIXME: Segment fault here???
         int mask = (1<<size)-1;
         if(likely((offset&7) + size <= 8)) {
             return ((((uint8_t* )(bits + (offset>>3)))[0] >> (offset&7)) & mask) == mask;

--- a/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.cpp
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.cpp
@@ -1,7 +1,7 @@
 /*
  * S2E Selective Symbolic Execution Framework
  *
- * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * Copyright (c) 2015, Information Security Laboratory, NUDT
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,10 +25,6 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * Currently maintained by:
- *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
- *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
  *
  * All contributors are listed in S2E-AUTHORS file.
  *

--- a/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.cpp
@@ -1,0 +1,138 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Currently maintained by:
+ *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
+ *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+extern "C" {
+#include "config.h"
+#include <qemu-common.h>
+#include <cpu-all.h>
+#include <exec-all.h>
+#include <sysemu.h>
+#include <cpus.h>
+}
+
+#include "AutoShFileGenerator.h"
+#include <iomanip>
+#include <cctype>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
+#include <s2e/S2E.h>
+#include <s2e/S2EExecutor.h>
+#include <s2e/Utils.h>
+#include <s2e/ConfigFile.h>
+
+#include <s2e/Plugin.h>
+#include <s2e/s2e_qemu.h>
+#include <s2e/S2EExecutionState.h>
+#include <s2e/S2ESJLJ.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdlib.h>    /**/
+#include <errno.h>     /*errno*/
+#include <unistd.h>    /*ssize_t*/
+#include <sys/types.h>
+#include <sys/stat.h>  /*mode_t*/
+
+#include <stdlib.h>
+#include <llvm/Support/TimeValue.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Path.h>
+
+namespace s2e {
+namespace plugins {
+S2E_DEFINE_PLUGIN(AutoShFileGenerator, "AutoShFileGenerator plugin",
+        "AutoShFileGenerator",);
+
+AutoShFileGenerator::AutoShFileGenerator(S2E* s2e) :
+        Plugin(s2e)
+{
+    m_current_command = " ";
+    m_randtemplate = "{seed}";
+}
+
+AutoShFileGenerator::~AutoShFileGenerator()
+{
+}
+void AutoShFileGenerator::initialize()
+{
+    bool ok = false;
+    m_command_file = s2e()->getConfig()->getString(
+            getConfigKey() + ".command_file", "", &ok);
+    if (!ok) {
+        s2e()->getWarningsStream() << "You must specifiy "
+                << getConfigKey() + ".command_file" << '\n';
+        exit(-1);
+    }
+    m_command_str = s2e()->getConfig()->getString(
+            getConfigKey() + ".command_str", "", &ok);
+    if (!ok) {
+        s2e()->getWarningsStream() << "You must specifiy"
+                << getConfigKey() + ".command_str" << "in XXX{seed}XXX form\n";
+        exit(-1);
+    }
+    s2e()->getCorePlugin()->onStateKill.connect(
+    sigc::mem_fun(*this, &AutoShFileGenerator::onStateKill));
+
+    generateCmdFile();
+}
+void AutoShFileGenerator::generateCmdFile()
+{
+    std::ofstream cfile(m_command_file.c_str());
+    //Here we give a random replace so that we can randomly mark symbolic in s2ecmd
+    m_current_command = replace_randtemplate(m_command_str);
+    cfile << m_current_command;
+    cfile.close();
+}
+void AutoShFileGenerator::onStateKill(S2EExecutionState* state)
+{
+    generateCmdFile();
+}
+std::string AutoShFileGenerator::replace_randtemplate(std::string in_str)
+{
+    std::string out_str = in_str;
+    int pos = in_str.find(m_randtemplate);
+    std::stringstream target;
+    target << rand() % 65536;
+    if (in_str.find(m_randtemplate) != std::string::npos) {
+        out_str = in_str.replace(pos, m_randtemplate.length(), target.str());
+    }
+    return out_str;
+}
+} /* namespace plugins */
+} /* namespace s2e */

--- a/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.h
+++ b/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.h
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.h
+++ b/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.h
@@ -1,7 +1,7 @@
 /*
  * S2E Selective Symbolic Execution Framework
  *
- * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * Copyright (c) 2015, Information Security Laboratory, NUDT
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,10 +25,6 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * Currently maintained by:
- *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
- *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
  *
  * All contributors are listed in S2E-AUTHORS file.
  *

--- a/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.h
+++ b/qemu/s2e/Plugins/AFLControllers/AutoShFileGenerator.h
@@ -1,0 +1,78 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Currently maintained by:
+ *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
+ *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#ifndef AUTOSHFILEGENERATOR_H_
+
+#define AUTOSHFILEGENERATOR_H_
+
+#include <string>
+#include <s2e/Plugin.h>
+#include <s2e/Plugins/CorePlugin.h>
+#include <s2e/S2EExecutionState.h>
+namespace s2e {
+namespace plugins {
+/**
+ * Generate an auto start shell script to avoid tedious manual work
+ */
+class AutoShFileGenerator: public Plugin
+{
+S2E_PLUGIN
+
+    typedef std::pair<std::string, std::vector<unsigned char> > VarValuePair;
+    typedef std::vector<VarValuePair> ConcreteInputs;
+    std::string m_command_str;  //cmdline string
+    std::string m_command_file; // where to generate the file
+    std::string m_current_command;
+    void onStateKill(S2EExecutionState* state);
+
+    std::string m_randtemplate;
+
+public:
+    AutoShFileGenerator(S2E* s2e);
+    void initialize();
+    void generateCmdFile();
+    virtual ~AutoShFileGenerator();
+    std::string replace_randtemplate(std::string in_str);
+    std::string getCurrentCommand()
+    {
+        return m_current_command;
+    }
+};
+
+} /* namespace plugins */
+} /* namespace s2e */
+
+#endif /* !AUTOSHFILEGENERATOR_H_ */

--- a/qemu/s2e/Plugins/AFLControllers/ForkController.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/ForkController.cpp
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/ForkController.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/ForkController.cpp
@@ -1,0 +1,151 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Currently maintained by:
+ *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
+ *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#include "ForkController.h"
+#include <s2e/S2E.h>
+#include <s2e/ConfigFile.h>
+#include <s2e/Utils.h>
+
+#include <iostream>
+namespace s2e {
+namespace plugins {
+S2E_DEFINE_PLUGIN(ForkController, "ForkController plugin", "ForkController",
+        "ModuleExecutionDetector");
+
+ForkController::~ForkController()
+{
+}
+void ForkController::initialize()
+{
+    ConfigFile *cfg = s2e()->getConfig();
+    ConfigFile::string_list pollingEntries = cfg->getListKeys(
+            getConfigKey() + ".forkRanges");
+    if (pollingEntries.size() == 0) {
+        Range rg;
+        rg.start = 0x00000000;
+        rg.end = 0xC0000000; // we do not check the kernel
+        m_forkRanges.insert(rg);
+    } else {
+        foreach2(it, pollingEntries.begin(), pollingEntries.end())
+        {
+            std::stringstream ss1;
+            ss1 << getConfigKey() << ".forkRanges" << "." << *it;
+            ConfigFile::integer_list il = cfg->getIntegerList(ss1.str());
+            if (il.size() != 2) {
+                s2e()->getWarningsStream() << "Range entry " << ss1.str()
+                        << " must be of the form {startPc, endPc} format"
+                        << '\n';
+                continue;
+            }
+
+            bool ok = false;
+            uint64_t start = cfg->getInt(ss1.str() + "[1]", 0, &ok);
+            if (!ok) {
+                s2e()->getWarningsStream() << "could not read " << ss1.str()
+                        << "[0]" << '\n';
+                continue;
+            }
+
+            uint64_t end = cfg->getInt(ss1.str() + "[2]", 0, &ok);
+            if (!ok) {
+                s2e()->getWarningsStream() << "could not read " << ss1.str()
+                        << "[1]" << '\n';
+                continue;
+            }
+            //Convert the format to native address
+            Range rg;
+            rg.start = start;
+            rg.end = end;
+            m_forkRanges.insert(rg);
+        }
+    }
+    m_detector = static_cast<ModuleExecutionDetector*>(s2e()->getPlugin(
+            "ModuleExecutionDetector"));
+    if (m_detector) {
+        s2e()->getCorePlugin()->onTranslateBlockStart.connect(
+        sigc::mem_fun(*this, &ForkController::onTranslateBlockStart));
+        s2e()->getCorePlugin()->onTranslateBlockEnd.connect(
+        sigc::mem_fun(*this, &ForkController::onTranslateBlockEnd));
+    }
+}
+
+void ForkController::onTranslateBlockStart(ExecutionSignal* es,
+        S2EExecutionState* state, TranslationBlock* tb, uint64_t pc)
+{
+    if (!tb) {
+        return;
+    }
+    es->connect(sigc::mem_fun(*this, &ForkController::slotExecuteBlockStart));
+}
+void ForkController::onTranslateBlockEnd(ExecutionSignal *signal,
+        S2EExecutionState* state, TranslationBlock *tb, uint64_t endPc,
+        bool staticTarget, uint64_t targetPc)
+{
+    if (!tb) {
+        return;
+    }
+    signal->connect(sigc::mem_fun(*this, &ForkController::slotExecuteBlockEnd));
+}
+/**
+ */
+void ForkController::slotExecuteBlockStart(S2EExecutionState *state,
+        uint64_t pc)
+{
+    if (state->isSymbolicExecutionEnabled()) {
+        bool found = false;
+        if (!found) {
+            foreach2(rgit, m_forkRanges.begin(), m_forkRanges.end())
+            {
+                if ((pc >= (*rgit).start) && (pc <= (*rgit).end)) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (found) {
+            state->enableForking();
+        }
+    }
+}
+
+void ForkController::slotExecuteBlockEnd(S2EExecutionState *state, uint64_t pc)
+{
+    if (state->isForkingEnabled())
+        state->disableForking();
+}
+
+}
+} /* namespace s2e */

--- a/qemu/s2e/Plugins/AFLControllers/ForkController.h
+++ b/qemu/s2e/Plugins/AFLControllers/ForkController.h
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/ForkController.h
+++ b/qemu/s2e/Plugins/AFLControllers/ForkController.h
@@ -1,0 +1,79 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Currently maintained by:
+ *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
+ *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#ifndef FORKCONTROLLER_H_
+
+#define FORKCONTROLLER_H_
+
+#include <s2e/Plugin.h>
+#include <s2e/Plugins/CorePlugin.h>
+#include <s2e/S2EExecutionState.h>
+#include <s2e/Plugins/ModuleExecutionDetector.h>
+#include <s2e/Plugins/WindowsInterceptor/WindowsMonitor.h>
+namespace s2e {
+namespace plugins {
+
+class ForkController: public Plugin
+{
+S2E_PLUGIN
+
+    ModuleExecutionDetector *m_detector;
+    RangeEntries m_forkRanges;
+
+public:
+    virtual ~ForkController();
+    ForkController(S2E* s2e) :
+            Plugin(s2e)
+    {
+        m_detector = NULL;
+    }
+    void initialize();
+
+public:
+    void slotExecuteBlockStart(S2EExecutionState* state, uint64_t pc);
+    void slotExecuteBlockEnd(S2EExecutionState* state, uint64_t pc);
+
+    void onTranslateBlockStart(ExecutionSignal*, S2EExecutionState*,
+            TranslationBlock*, uint64_t);
+    void onTranslateBlockEnd(ExecutionSignal *signal, S2EExecutionState* state,
+            TranslationBlock *tb, uint64_t endPc, bool staticTarget,
+            uint64_t targetPc);
+};
+
+} // namespace plugins
+} // namespace s2e
+
+#endif /* FORKCONTROLLER_H_ */

--- a/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.cpp
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.cpp
@@ -1,0 +1,954 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Currently maintained by:
+ *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
+ *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#include "FuzzySearcher.h"
+extern "C" {
+#include <qemu-common.h>
+#include <cpu-all.h>
+#include <exec-all.h>
+#include <sysemu.h>
+#include <sys/shm.h>
+}
+#include <s2e/S2E.h>
+#include <s2e/S2EExecutor.h>
+#include <s2e/ConfigFile.h>
+#include <s2e/Utils.h>
+
+#include <iomanip>
+#include <cctype>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdlib.h>    /**/
+#include <errno.h>     /*errno*/
+#include <unistd.h>    /*ssize_t*/
+#include <sys/types.h>
+#include <sys/stat.h>  /*mode_t*/
+#include <stdlib.h>
+
+using namespace llvm::sys;
+
+//#define DEBUG
+
+extern "C" void kbd_put_keycode(int keycode);
+
+std::string g_inicasepool = "/tmp/inipool/";
+std::string g_curcasepool = "/tmp/curpool/";
+
+namespace s2e {
+namespace plugins {
+
+S2E_DEFINE_PLUGIN(FuzzySearcher, "FuzzySearcher plugin", "FuzzySearcher",
+        "ModuleExecutionDetector", "HostFiles");
+
+FuzzySearcher::~FuzzySearcher()
+{
+}
+void FuzzySearcher::initialize()
+{
+    bool ok = false;
+    std::string cfgkey = getConfigKey();
+    //afl related
+    m_aflOutputpool = s2e()->getConfig()->getString(cfgkey + ".aflOutput", "",
+            &ok);
+    if (!ok) {
+        s2e()->getDebugStream()
+                << "FuzzySearcher: You should specify AFL's output directory as aflOutputpool\n";
+        exit(0);
+    }
+    m_aflRoot = s2e()->getConfig()->getString(cfgkey + ".aflRoot", "", &ok);
+    if (!ok) {
+        s2e()->getDebugStream()
+                << "FuzzySearcher: You should specify AFL's root directory as aflRoot\n";
+        exit(0);
+    }
+    m_aflAppArgs = s2e()->getConfig()->getString(cfgkey + ".aflAppArgs", "",
+            &ok);
+    if (!ok) {
+        s2e()->getDebugStream()
+                << "FuzzySearcher: You should specify target binary's full arguments as aflAppArgs\n";
+        exit(0);
+    }
+    m_aflBinaryMode = s2e()->getConfig()->getBool(
+            getConfigKey() + ".aflBinaryMode", false, &ok);
+    m_MAXLOOPs = s2e()->getConfig()->getInt(getConfigKey() + ".MaxLoops", 10,
+            &ok);
+    m_verbose = s2e()->getConfig()->getBool(getConfigKey() + ".debugVerbose",
+            false, &ok);
+    m_symbolicfilename = s2e()->getConfig()->getString(
+            cfgkey + ".symbolicfilename", "testcase", &ok);
+    m_inicasepool = s2e()->getConfig()->getString(cfgkey + ".inicasepool",
+            g_inicasepool, &ok);
+    m_curcasepool = s2e()->getConfig()->getString(cfgkey + ".curcasepool",
+            g_curcasepool, &ok);
+    //find the path
+    if (access(m_inicasepool.c_str(), F_OK)) {
+        std::cerr << "Could not find directory " << m_inicasepool << '\n';
+        exit(0);
+    }
+    if (access(m_curcasepool.c_str(), F_OK)) {
+        std::cerr << "Could not find directory " << m_curcasepool << '\n';
+        exit(0);
+    }
+
+    std::string mkdirError;
+    std::string generated_dir = s2e()->getOutputDirectory() + "/testcases";
+    Path generateDir(generated_dir);
+#ifdef _WIN32
+    if (generateDir.createDirectoryOnDisk(false, &mkdirError)) {
+#else
+    if (generateDir.createDirectoryOnDisk(true, &mkdirError)) {
+#endif
+        std::cerr << "Could not create directory " << generateDir.str()
+                << " error: " << mkdirError << '\n';
+    }
+
+    m_mainModule = s2e()->getConfig()->getString(cfgkey + ".mainModule",
+            "MainModule", &ok);
+
+    m_detector = static_cast<ModuleExecutionDetector*>(s2e()->getPlugin(
+            "ModuleExecutionDetector"));
+    if (!m_detector) {
+        std::cerr << "Could not find ModuleExecutionDetector plug-in. " << '\n';
+        exit(0);
+    }
+    m_hostFiles = static_cast<HostFiles*>(s2e()->getPlugin("HostFiles"));
+    m_AutoShFileGenerator = static_cast<AutoShFileGenerator*>(s2e()->getPlugin(
+            "AutoShFileGenerator"));
+    //
+    m_autosendkey_enter = s2e()->getConfig()->getBool(
+            getConfigKey() + ".autosendkey_enter", false, &ok);
+    m_autosendkey_interval = s2e()->getConfig()->getInt(
+            getConfigKey() + ".autosendkey_interval", 10, &ok);
+    m_firstInstructionTranslateStart =
+            s2e()->getCorePlugin()->onTranslateInstructionStart.connect(
+                    sigc::mem_fun(*this,
+                            &FuzzySearcher::slotFirstInstructionTranslateStart));
+    s2e()->getCorePlugin()->onStateSwitchEnd.connect(
+    sigc::mem_fun(*this, &FuzzySearcher::onStateSwitchEnd));
+    s2e()->getCorePlugin()->onStateKill.connect(
+    sigc::mem_fun(*this, &FuzzySearcher::onStateKill));
+    m_detector->onModuleLoad.connect(
+    sigc::mem_fun(*this, &FuzzySearcher::onModuleLoad));
+    m_detector->onModuleTranslateBlockStart.connect(
+    sigc::mem_fun(*this, &FuzzySearcher::onModuleTranslateBlockStart));
+    m_detector->onModuleTranslateBlockEnd.connect(
+    sigc::mem_fun(*this, &FuzzySearcher::onModuleTranslateBlockEnd));
+    s2e()->getExecutor()->setSearcher(this);
+}
+
+//return *states[theRNG.getInt32()%states.size()];
+
+klee::ExecutionState& FuzzySearcher::selectState()
+{
+    klee::ExecutionState *state;
+    if (!m_speculativeStates.empty()) { //to maximum random, priority to speculative state
+        States::iterator it = m_speculativeStates.begin();
+        int random_index = rand() % m_speculativeStates.size(); //random select a testcase
+        while (random_index) {
+            it++;
+            random_index--;
+        }
+        state = *it;
+        if (state->m_is_carry_on_state) { // we cannot execute carry on state, because it is the seed
+            if (m_speculativeStates.size() > 1) {
+                ++it;
+                if (it == m_speculativeStates.end()) {
+                    it--;
+                    it--;
+                }
+                state = *it;
+            } else if (!m_normalStates.empty()) {
+                state = *m_normalStates.begin();
+            }
+        }
+    } else {
+        assert(!m_normalStates.empty());
+        States::iterator it = m_normalStates.begin();
+        int random_index = rand() % m_normalStates.size();
+        while (random_index) {
+            it++;
+            random_index--;
+        }
+        state = *it;
+        if (state->m_is_carry_on_state) { //we cannot execute carry on state, because it is the seed
+            if (m_normalStates.size() > 1) {
+                ++it;
+                if (it == m_normalStates.end()) {
+                    it--;
+                    it--;
+                }
+                state = *it;
+            }
+        }
+    }
+
+    if (state->m_silently_concretized) { // we don't want the silently concretized state
+        s2e()->getDebugStream()
+                << "FuzzySearcher: we are in a silently concretized state\n";
+        if (m_normalStates.find(state) != m_normalStates.end()) {
+            m_normalStates.erase(state);
+            if (m_normalStates.empty())
+                s2e()->getDebugStream()
+                        << "FuzzySearcher: m_normalStates's size is " << "0"
+                        << "\n";
+            else
+                s2e()->getDebugStream()
+                        << "FuzzySearcher: m_normalStates's size is"
+                        << m_normalStates.size() << "\n";
+        } else {
+            m_speculativeStates.erase(state);
+            if (m_speculativeStates.empty())
+                s2e()->getDebugStream()
+                        << "FuzzySearcher: m_speculativeStates's size is "
+                        << "0" << "\n";
+            else
+                s2e()->getDebugStream()
+                        << "FuzzySearcher: m_speculativeStates's size is"
+                        << m_speculativeStates.size() << "\n";
+        }
+        return selectState();
+    }
+    return *state;
+}
+
+void FuzzySearcher::update(klee::ExecutionState *current,
+        const std::set<klee::ExecutionState*> &addedStates,
+        const std::set<klee::ExecutionState*> &removedStates)
+{
+    if (current && addedStates.empty() && removedStates.empty()) {
+        S2EExecutionState *s2estate = dynamic_cast<S2EExecutionState*>(current);
+        if (!s2estate->isZombie()) {
+            if (current->isSpeculative()) {
+                m_normalStates.erase(current);
+                m_speculativeStates.insert(current);
+            } else {
+                m_speculativeStates.erase(current);
+                m_normalStates.insert(current);
+            }
+        }
+    }
+
+    foreach2(it, removedStates.begin(), removedStates.end())
+    {
+        if (*it == NULL)
+            continue;
+        S2EExecutionState *es = dynamic_cast<S2EExecutionState*>(*it);
+        if (es->isSpeculative()) {
+            m_speculativeStates.erase(es);
+            s2e()->getDebugStream() << "m_speculativeStates.erase --- 2\n";
+        } else {
+            m_normalStates.erase(es);
+            s2e()->getDebugStream() << "m_normalStates.erase --- 2\n";
+        }
+    }
+
+    foreach2(it, addedStates.begin(), addedStates.end())
+    {
+        if (*it == NULL)
+            continue;
+        S2EExecutionState *es = dynamic_cast<S2EExecutionState*>(*it);
+        if (es->isSpeculative()) {
+            m_speculativeStates.insert(es);
+            s2e()->getDebugStream()
+                    << "FuzzySearcher: Insert speculative State, m_speculativeStates' size is "
+                    << m_speculativeStates.size() << ", state is"
+                    << (es->m_is_carry_on_state ? "" : " not")
+                    << " carry on state\n";
+        } else {
+            m_normalStates.insert(es);
+            s2e()->getDebugStream()
+                    << "FuzzySearcher: Insert normal State, m_normalStates' size is "
+                    << m_normalStates.size() << ", state is"
+                    << (es->m_is_carry_on_state ? "" : " not")
+                    << " carry on state\n";
+        }
+    }
+
+}
+bool FuzzySearcher::empty()
+{
+    return m_normalStates.empty() && m_speculativeStates.empty();
+}
+
+void FuzzySearcher::slotFirstInstructionTranslateStart(ExecutionSignal *signal,
+        S2EExecutionState *state, TranslationBlock *tb, uint64_t pc)
+{
+    if (!m_isfirstInstructionProcessed) {
+        m_firstInstructionProcess = signal->connect(
+        sigc::mem_fun(*this, &FuzzySearcher::ProcessFirstInstruction)); // we start from the very beginning of this state
+    }
+}
+void FuzzySearcher::ProcessFirstInstruction(S2EExecutionState* state,
+        uint64_t pc)
+{
+    if (!m_isfirstInstructionProcessed) {
+        prepareNextState(state, true);
+        m_isfirstInstructionProcessed = true;
+        m_firstInstructionProcess.disconnect(); // we only do this once time
+        m_firstInstructionTranslateStart.disconnect(); // we only do this once time
+    }
+}
+void FuzzySearcher::onStateSwitchEnd(S2EExecutionState *currentState,
+        S2EExecutionState *nextState)
+{
+    s2e()->getDebugStream()
+            << "FuzzySearcher: Capture state switch end event, give a chance to handle it.\n";
+    // terminate the last state and generate testcase
+    if (currentState && !(currentState->m_is_carry_on_state)) {
+        s2e()->getExecutor()->terminateStateEarly(*currentState,
+                "FuzzySearcher: terminate this for fuzzing");
+    }
+    if (currentState && (currentState->m_silently_concretized)) {
+        //s2e()->getExecutor()->terminateStateEarly(*currentState, "FuzzySearcher: terminate silently concretized state");
+    }
+    // if S2E only has the carry on state, then carry on to next iteration
+    if (nextState && nextState->m_is_carry_on_state) {
+        if (m_verbose) {
+            s2e()->getDebugStream()
+                    << "FuzzySearcher: We only have the seed state, now fetching new testcase.\n";
+        }
+        /*
+         * AFLROOT=/home/epeius/work/afl-1.96b
+         * $AFLROOT/afl-fuzz -m 4096M -t 50000 -i /home/epeius/work/DSlab.EPFL/FinalTest/evincetest/seeds/ -o /home/epeius/work/DSlab.EPFL/FinalTest/evincetest/res/ -Q /usr/bin/evince @@
+         */
+        if (!m_AFLStarted) { //if AFL not started, then starts it
+            std::stringstream aflCmdline;
+            std::string generated_dir = s2e()->getOutputDirectory()
+                    + "/testcases";
+            aflCmdline << m_aflRoot << "afl-fuzz -m 4096M -t 5000 -i "
+                    << generated_dir << " -o " << m_aflOutputpool
+                    << (m_aflBinaryMode ? " -Q " : "") << m_aflAppArgs << " &";
+            if (m_verbose) {
+                s2e()->getDebugStream()
+                        << "FuzzySearcher: AFL command line is: "
+                        << aflCmdline.str() << "\n";
+            }
+            system(aflCmdline.str().c_str()); //we don't want to suspend it, so we add "&":
+            m_AFLStarted = true;
+            sleep(10); //let us wait for new testcases
+        }
+
+        assert(m_AFLStarted && "AFL has not started, why?");
+        {
+            std::stringstream ssAflQueue;
+            ssAflQueue << m_aflOutputpool << "queue/";
+            Path inicasepool_llvm(m_inicasepool);
+            Path aflqueuecasepool_llvm(ssAflQueue.str());
+            ClearbeforeCopyto(inicasepool_llvm, aflqueuecasepool_llvm);
+        }
+        prepareNextState(nextState);
+    }
+}
+
+void FuzzySearcher::onStateKill(S2EExecutionState *currentState)
+{
+    //generate the testcase for AFL
+    //step1. construct name and generate the testcase
+    std::stringstream ssgeneratedCase;
+    std::string destfilename;
+    if (1) {
+        ssgeneratedCase << "testcases/" << getCurrentLoop() << "-"
+                << currentState->getID() << "-" << m_symbolicfilename; // Lopp-StateID-m_symbolicfilename
+        destfilename = s2e()->getOutputFilename(ssgeneratedCase.str().c_str());
+    } else {
+        ssgeneratedCase << m_aflOutputpool << "queue/" << getCurrentLoop()
+                << "-" << currentState->getID() << "-" << m_symbolicfilename; // Lopp-StateID-m_symbolicfilename
+        destfilename = ssgeneratedCase.str();
+    }
+    if (m_verbose) {
+        s2e()->getDebugStream() << "FuzzySearcher: Generating testcase: "
+                << destfilename << ".\n";
+    }
+    generateCaseFile(currentState, destfilename);
+}
+
+klee::Executor::StatePair FuzzySearcher::prepareNextState(
+        S2EExecutionState *state, bool isinitial)
+{
+
+    klee::Executor::StatePair sp;
+    state->jumpToSymbolicCpp();
+    bool oldForkStatus = state->isForkingEnabled();
+    state->enableForking();
+    if (isinitial) {
+        m_dummy_symb = state->createSymbolicValue("dummy_symb_var",
+                klee::Expr::Int32); // we need to create an initial state which can be used to continue execution
+        m_current_conditon = 0;
+    }
+    //	printf("FuzzySearcher: prepareNextState\n");
+    state->m_preparingstate = true;
+    std::vector<klee::Expr> conditions;
+    klee::ref<klee::Expr> cond = klee::NeExpr::create(m_dummy_symb,
+            klee::ConstantExpr::create(m_current_conditon, klee::Expr::Int32));
+    sp = s2e()->getExecutor()->fork(*state, cond, false);
+
+    S2EExecutionState *ts = static_cast<S2EExecutionState *>(sp.first);
+    S2EExecutionState *fs = static_cast<S2EExecutionState *>(sp.second);
+
+    klee::ref<klee::Expr> condnot = klee::EqExpr::create(m_dummy_symb,
+            klee::ConstantExpr::create(m_current_conditon, klee::Expr::Int32));
+    fs->addConstraint(condnot);
+
+    ts->setForking(oldForkStatus);
+    fs->setForking(oldForkStatus);
+
+    ts->m_is_carry_on_state = true;
+    fs->m_is_carry_on_state = false;
+
+    ts->m_preparingstate = false;
+    fs->m_preparingstate = false;
+
+    m_current_conditon++;
+
+    if (m_loops >= m_MAXLOOPs) { //reach the maximum
+        if (m_verbose) {
+            s2e()->getDebugStream() << "FuzzySearcher: Ready to exit\n";
+        }
+        CleanAndQuit();
+    }
+    //fetch a new testcase from pool
+    getNewCaseFromPool(fs);
+    m_loops += 1;
+    if (m_verbose) {
+        s2e()->getDebugStream() << "FuzzySearcher: Ready to start " << m_loops
+                << " iteration(s).\n";
+    }
+
+    m_key_enter_sent = false;
+    CorePlugin *plg = s2e()->getCorePlugin();
+    m_timerconn = plg->onTimer.connect(
+    sigc::mem_fun(*this, &FuzzySearcher::onTimer));
+    TimeValue curTime = TimeValue::now();
+    m_currentTime = curTime.seconds();
+    S2EExecutionState::resetLastSymbolicId();
+    s2e()->getExecutor()->updateStates(state);
+    return sp;
+}
+
+void FuzzySearcher::onTimer()
+{
+    TimeValue curTime = TimeValue::now();
+    if (m_currentTime < (curTime.seconds() - m_autosendkey_interval)) { // wait a while so that S2E can capture this key
+        m_currentTime = curTime.seconds();
+        //auto send kp-enter to start iteration so that we do not need to do it manually.
+        if (m_autosendkey_enter && !m_key_enter_sent) {
+            int keycode = 0x9c; //kp_enter
+
+            if (keycode & 0x80) {
+                kbd_put_keycode(0xe0);
+            }
+            kbd_put_keycode(keycode & 0x7f);
+
+            if (m_verbose) {
+                s2e()->getDebugStream()
+                        << "FuzzySearcher: Automatically sent kp_enter to QEMU.\n";
+            }
+            //kbd_put_keycode(keycode);
+            m_key_enter_sent = true;
+            m_timerconn.disconnect();
+        }
+    }
+
+}
+
+void FuzzySearcher::CleanAndQuit()
+{
+    try {
+        char cmd[] = "pgrep -l afl-fuzz";
+        FILE *pp = popen(cmd, "r");
+        if (!pp) {
+            s2e()->getDebugStream()
+                    << "FuzzySearcher: Cannot open the pipe to read\n";
+            exit(0);
+        }
+        char tmp[128]; //
+        while (fgets(tmp, sizeof(tmp), pp) != NULL) {
+            if (tmp[strlen(tmp) - 1] == '\n') {
+                tmp[strlen(tmp) - 1] = '\0';
+            }
+            std::string str_tmp = tmp;
+            str_tmp = str_tmp.substr(0, str_tmp.find_first_of(' '));
+            int tmpPid = atoi(str_tmp.c_str());
+            if (m_verbose) {
+                s2e()->getDebugStream() << "FuzzySearcher: try to kill pid: "
+                        << tmpPid << "\n";
+            }
+            kill(tmpPid, SIGKILL);
+        }
+        pclose(pp); //close pipe
+    } catch (...) {
+        s2e()->getDebugStream() << "FuzzySearcher: Cannot kill AFL, why?\n";
+    }
+    if (m_verbose) {
+        s2e()->getDebugStream()
+                << "FuzzySearcher: Reach the maxmium iteration, quitting...\n";
+    }
+    if(m_shmID){
+        // remove share memory
+        std::stringstream IPCRMCmdline;
+        IPCRMCmdline << "ipcrm -m " << m_shmID << " &";
+        system(IPCRMCmdline.str().c_str());
+    }
+    qemu_system_shutdown_request(); //XXX:This invocation will cause illegal instruction (ud2) if there has no return for current function
+    exit(0);
+}
+
+void FuzzySearcher::ClearbeforeCopyto(Path &dstDir, Path &srcDir)
+{
+    std::set<Path> taskfiles;
+    std::set<Path> oldfiles;
+    std::string ErrorMsg;
+    // clear the destination folder
+    if (!dstDir.getDirectoryContents(oldfiles, &ErrorMsg)) {
+        typeof(oldfiles.begin()) it = oldfiles.begin();
+        while (it != oldfiles.end()) {
+            (*it).eraseFromDisk();
+            it++;
+        }
+    }
+
+    if (!srcDir.getDirectoryContents(taskfiles, &ErrorMsg)) {
+        int taskcount = taskfiles.size();
+        if (m_verbose) {
+            s2e()->getDebugStream() << "FuzzySearcher: we found " << taskcount
+                    << " testcase(s) in " << srcDir.c_str() << "\n";
+        }
+        typeof(taskfiles.begin()) it = taskfiles.begin();
+        while (it != taskfiles.end()) {
+            std::string fullfilename = (*it).str();
+            const char *filename = basename(fullfilename.c_str());
+            if (!strcmp(filename, ".")) {
+                it++;
+                continue;
+            }
+            if (!strcmp(filename, "..")) {
+                it++;
+                continue;
+            }
+            //std::string filename = (*it).filename();
+            std::stringstream bckfile;
+            bckfile << m_inicasepool.c_str() << filename;
+            if (m_verbose) {
+                s2e()->getDebugStream() << "FuzzySearcher: Copying filename: "
+                        << (*it).str() << " from the queue to"
+                                " filename: " << bckfile.str() << "\n";
+            }
+            copyfile(fullfilename.c_str(), bckfile.str().c_str());
+            it++;
+        }
+
+    }
+}
+
+/**
+ * Fetch a new testcase
+ */
+S2EExecutionState* FuzzySearcher::getNewCaseFromPool(S2EExecutionState* instate)
+{
+    bool done = false;
+    int idlecounter = 0;
+    Path inicasepool_llvm(m_inicasepool);
+    Path curcasepool_llvm(m_curcasepool);
+    std::set<Path> oldfiles;
+    std::string ErrorMsg;
+    // clear the current testcase pool
+    if (!curcasepool_llvm.getDirectoryContents(oldfiles, &ErrorMsg)) {
+        typeof(oldfiles.begin()) it = oldfiles.begin();
+        while (it != oldfiles.end()) {
+            (*it).eraseFromDisk();
+            it++;
+        }
+    }
+    while (!done) {
+        sleep(1);
+        idlecounter++;
+        std::set<Path> taskfiles;
+        std::string ErrorMsg;
+        if (!inicasepool_llvm.getDirectoryContents(taskfiles, &ErrorMsg)) {
+            int taskcount = taskfiles.size();
+            if (m_verbose) {
+                s2e()->getDebugStream() << "FuzzySearcher: Find " << taskcount
+                        << " testcases in the queue.\n";
+            }
+            if (taskcount <= 0) {
+                //pass
+            } else {
+                int selectindex = rand() % taskcount;
+                typeof(taskfiles.begin()) it = taskfiles.begin();
+                while (it != taskfiles.end()) {
+                    std::string fullfilename = (*it).str();
+                    const char *filename = basename(fullfilename.c_str());
+                    if (!filename) {
+                        s2e()->getDebugStream()
+                                << "FuzzySearcher: Could not allocate memory for file basename ---2.\n";
+                        exit(0); // must be interrupted
+                    }
+                    if (!strcmp(filename, ".") || !strcmp(filename, "..")) {
+                        it++;
+                        continue;
+                    } else {
+                        if (!selectindex) {
+                            try { // try to fetch this testcase and rename it so that the s2e guest can get it
+                                std::stringstream bckfile;
+                                bckfile << m_curcasepool.c_str()
+                                        << m_symbolicfilename;
+                                if (m_verbose) {
+                                    s2e()->getDebugStream()
+                                            << "FuzzySearcher: Copying filename: " << fullfilename
+                                            << " from the queue to filename: "
+                                            << bckfile.str() << "\n";
+                                }
+                                copyfile(fullfilename.c_str(), bckfile.str().c_str());
+                                done = true;
+                                break;
+                            } catch (...) {
+                                it++;
+                            }
+                        } else {
+                            selectindex -= 1;
+                            it++;
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+    return instate;
+}
+
+bool FuzzySearcher::generateCaseFile(S2EExecutionState *state,
+        std::string destfilename)
+{
+    //copy out template file to destination file
+    std::stringstream template_file;
+    template_file << m_curcasepool.c_str() << m_symbolicfilename;
+    if (!copyfile(template_file.str().c_str(), destfilename.c_str()))
+        return false;
+    //try to solve the constraint and write the result to destination file
+    int fd = open(destfilename.c_str(), O_RDWR);
+    if (fd < 0) {
+        s2e()->getDebugStream() << "could not open dest file: "
+                << destfilename.c_str() << "\n";
+        close(fd);
+        return false;
+    }
+    /* Determine the size of the file */
+    off_t size = lseek(fd, 0, SEEK_END);
+    if (size < 0) {
+        s2e()->getDebugStream() << "could not determine the size of :"
+                << destfilename.c_str() << "\n";
+        close(fd);
+        return false;
+    }
+
+    off_t offset = 0;
+    std::string delim_str = "_";
+    const char *delim = delim_str.c_str();
+    char *p;
+    char maxvarname[1024] =
+    { 0 };
+    ConcreteInputs out;
+    bool success = s2e()->getExecutor()->getSymbolicSolution(*state, out);
+
+    if (!success) {
+        s2e()->getWarningsStream() << "Could not get symbolic solutions"
+                << '\n';
+        return false;
+    }
+    ConcreteInputs::iterator it;
+    for (it = out.begin(); it != out.end(); ++it) {
+        const VarValuePair &vp = *it;
+        std::string varname = vp.first;
+        // "__symfile___%s___%d_%d_symfile__value_%02x",filename, offset,size,buffer[buffer_i]);
+        //parse offset
+        strcpy(maxvarname, varname.c_str());
+        if ((strstr(maxvarname, "symfile__value"))) {
+            strtok(maxvarname, delim);
+            strtok(NULL, delim);
+            strtok(NULL, delim);
+            //strtok(NULL, delim);
+            p = strtok(NULL, delim);
+            offset = atol(p);
+            if (lseek(fd, offset, SEEK_SET) < 0) {
+                s2e()->getDebugStream() << "could not seek to position : "
+                        << offset << "\n";
+                close(fd);
+                return false;
+            }
+        } else if ((strstr(maxvarname, "___symfile___"))) {
+            //v1___symfile___E:\case\huplayerpoc.m3u___27_2_symfile___0: 1a 00, (string) ".."
+            //__symfile___%s___%d_%d_symfile__
+            strtok(maxvarname, delim);
+            strtok(NULL, delim);
+            strtok(NULL, delim);
+            //strtok(NULL, delim);
+            p = strtok(NULL, delim);
+            offset = atol(p);
+            if (lseek(fd, offset, SEEK_SET) < 0) {
+                s2e()->getDebugStream() << "could not seek to position : "
+                        << offset << "\n";
+                close(fd);
+                return false;
+            }
+        } else {
+            continue;
+        }
+        unsigned wbuffer[1] =
+        { 0 };
+        for (unsigned i = 0; i < vp.second.size(); ++i) {
+            wbuffer[0] = (unsigned) vp.second[i];
+            ssize_t written_count = write(fd, wbuffer, 1);
+            if (written_count < 0) {
+                s2e()->getDebugStream() << " could not write to file : "
+                        << destfilename.c_str() << "\n";
+                close(fd);
+                return false;
+            }
+        }
+    }
+    close(fd);
+    return true;
+}
+
+#define BUFFER_SIZE 4
+bool FuzzySearcher::copyfile(const char* fromfile, const char* tofile)
+{
+    int from_fd, to_fd;
+    int bytes_read, bytes_write;
+    char buffer[BUFFER_SIZE];
+    char *ptr;
+
+    if ((from_fd = open(fromfile, O_RDONLY)) == -1) /*open file readonly*/
+    {
+        fprintf(stderr, "Open %s Error:%s\n", fromfile, strerror(errno));
+        return false;
+    }
+    if ((to_fd = open(tofile, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR)) == -1) {
+        fprintf(stderr, "Open %s Error:%s\n", tofile, strerror(errno));
+        return false;
+    }
+    while ((bytes_read = read(from_fd, buffer, BUFFER_SIZE))) {
+        if ((bytes_read == -1) && (errno != EINTR))
+            break;
+        else if (bytes_read > 0) {
+            ptr = buffer;
+            while ((bytes_write = write(to_fd, ptr, bytes_read))) {
+                if ((bytes_write == -1) && (errno != EINTR))
+                    break;
+                else if (bytes_write == bytes_read)
+                    break;
+                else if (bytes_write > 0) {
+                    ptr += bytes_write;
+                    bytes_read -= bytes_write;
+                }
+            }
+            if (bytes_write == -1)
+                break;
+        }
+    }
+    close(from_fd);
+    close(to_fd);
+    return true;
+}
+
+void FuzzySearcher::onModuleLoad(S2EExecutionState* state,
+        const ModuleDescriptor &md)
+{
+
+}
+
+void FuzzySearcher::onModuleTranslateBlockStart(ExecutionSignal* es,
+        S2EExecutionState* state, const ModuleDescriptor &mod,
+        TranslationBlock* tb, uint64_t pc)
+{
+    if (!tb) {
+        return;
+    }
+    if (m_mainModule == mod.Name) {
+        es->connect(
+        sigc::mem_fun(*this, &FuzzySearcher::slotExecuteBlockStart));
+    }
+
+}
+void FuzzySearcher::onModuleTranslateBlockEnd(ExecutionSignal *signal,
+        S2EExecutionState* state, const ModuleDescriptor &module,
+        TranslationBlock *tb, uint64_t endPc, bool staticTarget,
+        uint64_t targetPc)
+{
+    if (!tb) {
+        return;
+    }
+    if (m_mainModule == module.Name) {
+        signal->connect(
+        sigc::mem_fun(*this, &FuzzySearcher::slotExecuteBlockEnd));
+    }
+
+}
+/**
+ */
+void FuzzySearcher::slotExecuteBlockStart(S2EExecutionState *state, uint64_t pc)
+{
+    const ModuleDescriptor *curMd = m_detector->getCurrentDescriptor(state);
+    if (!curMd) {
+        return;
+    }
+    if (m_verbose) {
+        s2e()->getDebugStream(state)
+                << "FuzzySearcher: Find module when executing, we are in "
+                << curMd->Name << ", current BB is: " << hexval(pc) << ".\n";
+    }
+    // do work here.
+    if (!m_AFLStarted)			//let AFL create the bitmap
+        return;
+    if (!m_findBitMapSHM) {
+        m_findBitMapSHM = getAFLBitmapSHM();
+    } else {
+        assert(m_aflBitmapSHM && "AFL's bitmap is NULL, why??");
+        DECLARE_PLUGINSTATE(FuzzySearcherState, state);
+        /*
+         * cur_location = (block_address >> 4) ^ (block_address << 8);
+         shared_mem[cur_location ^ prev_location]++;
+         prev_location = cur_location >> 1;
+         */
+#ifdef DEBUG
+        s2e()->getDebugStream(state)
+        << "FuzzySearcher: Ready to update AFL bitmap.\n";
+        bool success = plgState->updateAFLBitmapSHM(m_aflBitmapSHM, pc);
+        if (success)
+        s2e()->getDebugStream(state)
+        << "FuzzySearcher: Successfully updated AFL bitmap.\n";
+        else
+        s2e()->getDebugStream(state)
+        << "FuzzySearcher: Failed to update AFL bitmap.\n";
+#else
+        plgState->updateAFLBitmapSHM(m_aflBitmapSHM, pc);
+#endif
+    }
+}
+
+void FuzzySearcher::slotExecuteBlockEnd(S2EExecutionState *state, uint64_t pc)
+{
+
+}
+
+bool FuzzySearcher::getAFLBitmapSHM()
+{
+    m_aflBitmapSHM = NULL;
+    key_t shmkey;
+    do {
+        if ((shmkey = ftok("/tmp/aflbitmap", 1)) < 0) {
+            s2e()->getDebugStream() << "FuzzySearcher: ftok() error: "
+                    << strerror(errno) << "\n";
+            return false;
+        }
+        int shm_id;
+        try {
+            if (!m_findBitMapSHM)
+                sleep(5);			//wait afl for a while
+            shm_id = shmget(shmkey, AFL_BITMAP_SIZE, IPC_CREAT | 0600);
+            if (shm_id < 0) {
+                s2e()->getDebugStream() << "FuzzySearcher: shmget() error: "
+                        << strerror(errno) << "\n";
+                return false;
+            }
+            void * afl_area_ptr = shmat(shm_id, NULL, 0);
+            if (afl_area_ptr == (void*) -1) {
+                s2e()->getDebugStream() << "FuzzySearcher: shmat() error: "
+                        << strerror(errno) << "\n";
+                exit(1);
+            }
+            m_aflBitmapSHM = (unsigned char*) afl_area_ptr;
+            m_findBitMapSHM = true;
+            m_shmID = shm_id;
+            if (m_verbose) {
+                s2e()->getDebugStream() << "FuzzySearcher: Share memory id is "
+                        << shm_id << "\n";
+            }
+        } catch (...) {
+            return false;
+        }
+    } while (0);
+    return true;
+}
+
+bool FuzzySearcherState::updateAFLBitmapSHM(unsigned char* AflBitmap,
+        uint64_t curBBpc)
+{
+    uint64_t cur_location = (curBBpc >> 4) ^ (curBBpc << 8);
+    cur_location &= AFL_BITMAP_SIZE - 1;
+    if (cur_location >= AFL_BITMAP_SIZE)
+        return false;
+    AflBitmap[cur_location ^ m_prev_loc]++;
+    m_prev_loc = cur_location >> 1;
+    return true;
+}
+FuzzySearcherState::FuzzySearcherState()
+{
+    m_plugin = NULL;
+    m_state = NULL;
+    m_prev_loc = 0;
+}
+
+FuzzySearcherState::FuzzySearcherState(S2EExecutionState *s, Plugin *p)
+{
+    m_plugin = static_cast<FuzzySearcher*>(p);
+    m_state = s;
+    m_prev_loc = 0;
+}
+
+FuzzySearcherState::~FuzzySearcherState()
+{
+}
+
+PluginState *FuzzySearcherState::clone() const
+{
+    return new FuzzySearcherState(*this);
+}
+
+PluginState *FuzzySearcherState::factory(Plugin *p, S2EExecutionState *s)
+{
+    FuzzySearcherState *ret = new FuzzySearcherState(s, p);
+    return ret;
+}
+}
+} /* namespace s2e */

--- a/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.h
+++ b/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.h
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.h
+++ b/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.h
@@ -1,0 +1,221 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Currently maintained by:
+ *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
+ *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#ifndef FUZZYSEARCHER_H_
+
+#define FUZZYSEARCHER_H_
+
+#include <s2e/Plugin.h>
+#include <s2e/Plugins/CorePlugin.h>
+#include <s2e/S2EExecutionState.h>
+#include <s2e/Plugins/FunctionMonitor.h>
+#include <s2e/Plugins/ModuleExecutionDetector.h>
+#include <s2e/Plugins/HostFiles.h>
+#include <s2e/S2EExecutor.h>
+#include <s2e/ConfigFile.h>
+#include <klee/Searcher.h>
+#include <vector>
+#include "klee/util/ExprEvaluator.h"
+#include "AutoShFileGenerator.h"
+#include <llvm/Support/TimeValue.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Path.h>
+
+namespace s2e {
+namespace plugins {
+class FuzzySearcher;
+
+class FuzzySearcherState: public PluginState
+{
+private:
+    FuzzySearcher* m_plugin;
+    S2EExecutionState *m_state;
+public:
+    //in order to improve efficiency, we write the branches of S2E to AFL's bitmap
+    uint64_t m_prev_loc; //previous location when executing
+    FuzzySearcherState();
+    FuzzySearcherState(S2EExecutionState *s, Plugin *p);
+    virtual ~FuzzySearcherState();
+    virtual PluginState *clone() const;
+    static PluginState *factory(Plugin *p, S2EExecutionState *s);
+
+    inline bool updateAFLBitmapSHM(unsigned char* bitmap, uint64_t pc);
+
+    friend class FuzzySearcher;
+};
+
+#define AFL_BITMAP_SIZE (1 << 16)
+
+class FuzzySearcher: public Plugin, public klee::Searcher
+{
+S2E_PLUGIN
+    struct SortById
+    {
+        bool operator ()(const klee::ExecutionState *_s1,
+                const klee::ExecutionState *_s2) const
+        {
+            const S2EExecutionState *s1 =
+                    static_cast<const S2EExecutionState*>(_s1);
+            const S2EExecutionState *s2 =
+                    static_cast<const S2EExecutionState*>(_s2);
+
+            return s1->getID() < s2->getID();
+        }
+    };
+    typedef std::set<klee::ExecutionState*, SortById> States;
+    typedef std::set<std::string> StringSet;
+    typedef std::pair<std::string, std::vector<unsigned char> > VarValuePair;
+    typedef std::vector<VarValuePair> ConcreteInputs;
+    ModuleExecutionDetector *m_detector;
+    HostFiles *m_hostFiles;
+    AutoShFileGenerator *m_AutoShFileGenerator;
+public:
+    bool m_autosendkey_enter;
+    int64_t m_autosendkey_interval;
+    bool m_key_enter_sent;
+    uint64_t m_currentTime;sigc::connection m_timerconn;
+    States m_normalStates;
+    States m_speculativeStates;
+    klee::ref<klee::Expr> m_dummy_symb;
+    int m_current_conditon;
+    bool m_isfirstInstructionProcessed;sigc::connection m_firstInstructionTranslateStart;sigc::connection m_firstInstructionProcess;
+    virtual klee::ExecutionState& selectState();
+    virtual void update(klee::ExecutionState *current,
+            const std::set<klee::ExecutionState*> &addedStates,
+            const std::set<klee::ExecutionState*> &removedStates);
+    virtual bool empty();
+
+    void onTimer();
+    void ProcessFirstInstruction(S2EExecutionState* state, uint64_t pc);
+    klee::Executor::StatePair prepareNextState(S2EExecutionState *state,
+            bool isinitial = false);
+    S2EExecutionState* getNewCaseFromPool(S2EExecutionState* instate);
+    void slotFirstInstructionTranslateStart(ExecutionSignal *signal,
+            S2EExecutionState *state, TranslationBlock *tb, uint64_t pc);
+    void onStateSwitchEnd(S2EExecutionState *currentState,
+            S2EExecutionState *nextState);
+    void onStateKill(S2EExecutionState *State);
+    bool generateCaseFile(S2EExecutionState *state, std::string templatefile);
+    static bool copyfile(const char* fromfile, const char* tofile);
+    void CleanAndQuit(void);
+    void ClearbeforeCopyto(llvm::sys::Path &dstDir, llvm::sys::Path &srcDir);
+
+private:
+    /**
+     * schduelar
+     */
+    std::string m_inicasepool; //initial testcase's directory
+    std::string m_curcasepool; //current input directory(as a temple place)
+
+    // AFL related
+    std::string m_aflOutputpool; //AFL's output directory
+    std::string m_aflRoot; //AFL's root directory
+    bool m_aflBinaryMode; //whether to use binary mode
+    bool m_AFLStarted; //AFL started
+    std::string m_aflAppArgs; //arguments of targer binary code and replace the file with "@@"
+    int m_aflPid; //AFL's Pid
+    unsigned char* m_aflBitmapSHM; //AFL's bitmap
+    bool m_findBitMapSHM; //whether we have find bitmap
+    // AFL end
+
+    std::string m_symbolicfilename;	//
+
+    std::string m_hostfilebase;
+    std::string m_mainModule;	//main module name (i.e. target binary)
+
+    int m_idlecondition;
+
+    int m_loops;	//current iteration
+    int m_MAXLOOPs;	//stop condition
+    int m_shmID;
+
+    bool m_verbose; //verbose debug output
+
+public:
+    FuzzySearcher(S2E* s2e) :
+            Plugin(s2e)
+    {
+        m_hostFiles = NULL;
+        m_detector = NULL;
+        m_isfirstInstructionProcessed = false;
+        m_current_conditon = 0;
+        m_autosendkey_enter = true;
+        m_key_enter_sent = false;
+        m_autosendkey_interval = 10;
+        m_currentTime = 0;
+        m_idlecondition = 0;
+        m_loops = 0;
+        m_aflPid = 0;
+        m_aflBitmapSHM = 0;
+        m_shmID = 0;
+        m_findBitMapSHM = false;
+        m_AFLStarted = false;
+        m_aflBinaryMode = false;
+        m_verbose = false;
+    }
+    virtual ~FuzzySearcher();
+    void initialize();
+    /*
+     sigc::signal<void,
+     S2EExecutionState*,
+     const ModuleDescriptor &
+     >onModuleLoad;
+     */
+    void onModuleLoad(S2EExecutionState*, const ModuleDescriptor &);
+
+    void slotExecuteBlockStart(S2EExecutionState* state, uint64_t pc);
+    void slotExecuteBlockEnd(S2EExecutionState* state, uint64_t pc);
+
+    void onModuleTranslateBlockStart(ExecutionSignal*, S2EExecutionState*,
+            const ModuleDescriptor &, TranslationBlock*, uint64_t);
+    void onModuleTranslateBlockEnd(ExecutionSignal *signal,
+            S2EExecutionState* state, const ModuleDescriptor &module,
+            TranslationBlock *tb, uint64_t endPc, bool staticTarget,
+            uint64_t targetPc);
+
+    void onTestCaseGeneration(S2EExecutionState *state,
+            const std::string &message);
+    int getCurrentLoop(void) const
+    {
+        return m_loops;
+    }
+
+    bool getAFLBitmapSHM();
+};
+}
+} /* namespace s2e */
+
+#endif /* !FUZZYSEARCHER_H_ */

--- a/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.h
+++ b/qemu/s2e/Plugins/AFLControllers/FuzzySearcher.h
@@ -1,7 +1,7 @@
 /*
  * S2E Selective Symbolic Execution Framework
  *
- * Copyright (c) 2010, Dependable Systems Laboratory, EPFL
+ * Copyright (c) 2015, Information Security Laboratory, NUDT
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,10 +25,6 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * Currently maintained by:
- *    Vitaly Chipounov <vitaly.chipounov@epfl.ch>
- *    Volodymyr Kuznetsov <vova.kuznetsov@epfl.ch>
  *
  * All contributors are listed in S2E-AUTHORS file.
  *
@@ -60,7 +56,7 @@ class FuzzySearcher;
 
 class FuzzySearcherState: public PluginState
 {
-private:
+public:
     FuzzySearcher* m_plugin;
     S2EExecutionState *m_state;
 public:
@@ -82,6 +78,8 @@ public:
 class FuzzySearcher: public Plugin, public klee::Searcher
 {
 S2E_PLUGIN
+
+public:
     struct SortById
     {
         bool operator ()(const klee::ExecutionState *_s1,
@@ -102,7 +100,7 @@ S2E_PLUGIN
     ModuleExecutionDetector *m_detector;
     HostFiles *m_hostFiles;
     AutoShFileGenerator *m_AutoShFileGenerator;
-public:
+
     bool m_autosendkey_enter;
     int64_t m_autosendkey_interval;
     bool m_key_enter_sent;
@@ -125,7 +123,7 @@ public:
     S2EExecutionState* getNewCaseFromPool(S2EExecutionState* instate);
     void slotFirstInstructionTranslateStart(ExecutionSignal *signal,
             S2EExecutionState *state, TranslationBlock *tb, uint64_t pc);
-    void onStateSwitchEnd(S2EExecutionState *currentState,
+    virtual void onStateSwitchEnd(S2EExecutionState *currentState,
             S2EExecutionState *nextState);
     void onStateKill(S2EExecutionState *State);
     bool generateCaseFile(S2EExecutionState *state, std::string templatefile);
@@ -133,7 +131,7 @@ public:
     void CleanAndQuit(void);
     void ClearbeforeCopyto(llvm::sys::Path &dstDir, llvm::sys::Path &srcDir);
 
-private:
+public:
     /**
      * schduelar
      */
@@ -187,7 +185,7 @@ public:
         m_verbose = false;
     }
     virtual ~FuzzySearcher();
-    void initialize();
+    virtual void initialize();
     /*
      sigc::signal<void,
      S2EExecutionState*,

--- a/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.cpp
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.cpp
+++ b/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.cpp
@@ -1,0 +1,205 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2015, Information Security Laboratory, NUDT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#include "LoopFuzzer.h"
+extern "C" {
+#include <qemu-common.h>
+#include <cpu-all.h>
+#include <exec-all.h>
+#include <sysemu.h>
+#include <sys/shm.h>
+}
+#include <s2e/S2E.h>
+#include <s2e/S2EExecutor.h>
+#include <s2e/ConfigFile.h>
+#include <s2e/Utils.h>
+#include <s2e/Plugin.h>
+
+#include <iomanip>
+#include <cctype>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdlib.h>    /**/
+#include <errno.h>     /*errno*/
+#include <unistd.h>    /*ssize_t*/
+#include <sys/types.h>
+#include <sys/stat.h>  /*mode_t*/
+#include <stdlib.h>
+
+using namespace llvm::sys;
+
+namespace s2e {
+namespace plugins {
+
+S2E_DEFINE_PLUGIN(LoopFuzzer, "LoopFuzzer plugin", "LoopFuzzer",
+        "ModuleExecutionDetector", "HostFiles", "ForkController");
+
+LoopFuzzer::~LoopFuzzer()
+{
+}
+
+void LoopFuzzer::initialize()
+{
+    FuzzySearcher::initialize();
+    m_forkcontroller = static_cast<ForkController*>(s2e()->getPlugin(
+            "ForkController"));
+    if (!m_forkcontroller) {
+        std::cerr << "Could not find ForkController plug-in. " << '\n';
+        exit(0);
+    }
+    m_forkcontroller->onStuckinSymLoop.connect(
+    sigc::mem_fun(*this, &LoopFuzzer::onStuckinSymLoop));
+    m_forkcontroller->onGetoutfromSymLoop.connect(
+    sigc::mem_fun(*this, &LoopFuzzer::onGetoutfromSymLoop));
+}
+void LoopFuzzer::onStateSwitchEnd(S2EExecutionState *currentState,
+        S2EExecutionState *nextState)
+{
+    if (currentState && (currentState->m_silently_concretized)) {
+        //s2e()->getExecutor()->terminateStateEarly(*currentState, "FuzzySearcher: terminate silently concretized state");
+    }
+    // if S2E only has the carry on state, then carry on to next iteration
+    if (nextState && nextState->m_is_carry_on_state) {
+        if (m_verbose) {
+            s2e()->getDebugStream()
+                    << "LoopFuzzer: We only have the seed state, now fetching new testcase.\n";
+        }
+        if (!m_AFLStarted) { //if AFL not started, then starts it
+            startAFL();
+            m_AFLStarted = true;
+            sleep(10); //let us wait for new testcases
+        }
+        assert(m_AFLStarted && "AFL has not started, why?");
+        {
+            std::stringstream ssAflQueue;
+            ssAflQueue << m_aflOutputpool << "queue/";
+            Path inicasepool_llvm(m_inicasepool);
+            Path aflqueuecasepool_llvm(ssAflQueue.str());
+            ClearbeforeCopyto(inicasepool_llvm, aflqueuecasepool_llvm);
+        }
+        prepareNextState(nextState);
+    }
+}
+/*
+ * If we are stuck in a symbolic value controlled loop, because m_forkcontroller has helped us to
+ * control the fork, so here we just generate the testcase for AFL.
+ */
+void LoopFuzzer::onStuckinSymLoop(S2EExecutionState* state, uint64_t pc)
+{
+    //generate the testcase for AFL
+    //step1. construct name and generate the testcase
+    std::stringstream ssgeneratedCase;
+    std::string destfilename;
+    if (1) {
+        ssgeneratedCase << "testcases/" << getCurrentLoop() << "-"
+                << state->getID() << "-" << hexval(pc) << "-"
+                << m_symbolicfilename; // Lopp-StateID-pc-m_symbolicfilename
+        destfilename = s2e()->getOutputFilename(ssgeneratedCase.str().c_str());
+    } else {
+        ssgeneratedCase << m_aflOutputpool << "queue/" << getCurrentLoop()
+                << "-" << state->getID() << "-" << m_symbolicfilename; // Lopp-StateID-m_symbolicfilename
+        destfilename = ssgeneratedCase.str();
+    }
+    if (m_verbose) {
+        s2e()->getDebugStream() << "LoopFuzzer: Generating testcase: "
+                << destfilename << ".\n";
+    }
+    DECLARE_PLUGINSTATE(LoopFuzzerState, state);
+    if (!plgState->m_hasgeneratedtestcase) {
+        plgState->m_hasgeneratedtestcase = generateCaseFile(state,
+                destfilename);
+    }
+}
+
+void LoopFuzzer::onGetoutfromSymLoop(S2EExecutionState* state, uint64_t pc)
+{
+    if (m_verbose) {
+        s2e()->getDebugStream()
+                << "LoopFuzzer: we are getting from a loop and starting to execute BB: "
+                << hexval(pc) << ".\n";
+    }
+    DECLARE_PLUGINSTATE(LoopFuzzerState, state);
+    if (plgState->m_hasgeneratedtestcase)
+        plgState->m_hasgeneratedtestcase = false;
+}
+
+void LoopFuzzer::startAFL(void)
+{
+    std::stringstream aflCmdline;
+    std::string generated_dir = s2e()->getOutputDirectory() + "/testcases";
+    aflCmdline << m_aflRoot << "afl-fuzz -m 4096M -t 5000 -i " << generated_dir
+            << " -o " << m_aflOutputpool << (m_aflBinaryMode ? " -Q " : "")
+            << m_aflAppArgs << " &";
+    if (m_verbose) {
+        s2e()->getDebugStream() << "LoopFuzzer: AFL command line is: "
+                << aflCmdline.str() << "\n";
+    }
+    system(aflCmdline.str().c_str()); //we don't want to suspend it, so we add "&":
+}
+
+LoopFuzzerState::LoopFuzzerState()
+{
+    m_isinLoop = false;
+    m_hasgeneratedtestcase = false;
+}
+
+LoopFuzzerState::LoopFuzzerState(S2EExecutionState *s, Plugin *p)
+{
+    m_plugin = static_cast<LoopFuzzer*>(p);
+    m_state = s;
+    m_prev_loc = 0;
+    m_isinLoop = false;
+    m_hasgeneratedtestcase = false;
+}
+
+LoopFuzzerState::~LoopFuzzerState()
+{
+}
+
+PluginState *LoopFuzzerState::clone() const
+{
+    return new LoopFuzzerState(*this);
+}
+
+PluginState *LoopFuzzerState::factory(Plugin *p, S2EExecutionState *s)
+{
+    LoopFuzzerState *ret = new LoopFuzzerState(s, p);
+    return ret;
+}
+}
+} /* namespace s2e */

--- a/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.h
+++ b/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.h
@@ -11,14 +11,14 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *     * Neither the name of the Information Security Laboratory, NUDT nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * DISCLAIMED. IN NO EVENT SHALL THE INFORMATION SECURITY LABORATORY, NUDT BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND

--- a/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.h
+++ b/qemu/s2e/Plugins/AFLControllers/LoopFuzzer.h
@@ -1,0 +1,99 @@
+/*
+ * S2E Selective Symbolic Execution Framework
+ *
+ * Copyright (c) 2015, Information Security Laboratory, NUDT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Dependable Systems Laboratory, EPFL nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE DEPENDABLE SYSTEMS LABORATORY, EPFL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * All contributors are listed in S2E-AUTHORS file.
+ *
+ */
+
+#ifndef LOOPFUZZER_H_
+
+#define LOOPFUZZER_H_
+
+#include <s2e/Plugin.h>
+#include <s2e/Plugins/CorePlugin.h>
+#include <s2e/S2EExecutionState.h>
+#include <s2e/Plugins/FunctionMonitor.h>
+#include <s2e/Plugins/ModuleExecutionDetector.h>
+#include <s2e/Plugins/HostFiles.h>
+#include <s2e/S2EExecutor.h>
+#include <s2e/ConfigFile.h>
+#include <klee/Searcher.h>
+#include <vector>
+#include "klee/util/ExprEvaluator.h"
+#include "AutoShFileGenerator.h"
+#include <llvm/Support/TimeValue.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Path.h>
+
+#include "ForkController.h"
+#include "FuzzySearcher.h"
+
+namespace s2e {
+namespace plugins {
+
+class LoopFuzzer;
+
+class LoopFuzzerState: public FuzzySearcherState
+{
+public:
+    bool m_isinLoop;
+    bool m_hasgeneratedtestcase;
+public:
+    LoopFuzzerState();
+    LoopFuzzerState(S2EExecutionState *s, Plugin *p);
+    virtual ~LoopFuzzerState();
+    virtual PluginState *clone() const;
+    static PluginState *factory(Plugin *p, S2EExecutionState *s);
+    friend class LoopFuzzer;
+};
+
+class LoopFuzzer: public FuzzySearcher
+{
+S2E_PLUGIN
+
+public:
+    ForkController *m_forkcontroller;
+    virtual void onStateSwitchEnd(S2EExecutionState *currentState,
+            S2EExecutionState *nextState);
+
+public:
+    LoopFuzzer(S2E* s2e) :
+            FuzzySearcher(s2e)
+    {
+        m_forkcontroller = NULL;
+    }
+    void initialize();
+    void onStuckinSymLoop(S2EExecutionState* state, uint64_t pc);
+    void onGetoutfromSymLoop(S2EExecutionState* state, uint64_t pc);
+    void startAFL(void); // the arguments can be derived from current instance
+    ~LoopFuzzer();
+};
+}
+} /* namespace s2e */
+
+#endif /* !LOOPFUZZER_H_ */

--- a/qemu/s2e/Plugins/CorePlugin.h
+++ b/qemu/s2e/Plugins/CorePlugin.h
@@ -212,6 +212,11 @@ public:
                  S2EExecutionState*> /* nextState */
             onStateSwitch;
 
+    sigc::signal<void,
+				 S2EExecutionState*, /* currentState */
+				 S2EExecutionState*> /* nextState */
+			onStateSwitchEnd;
+
     /**
      * Triggered when S2E wants to generate a test case
      */

--- a/qemu/s2e/Plugins/OSMonitor.h
+++ b/qemu/s2e/Plugins/OSMonitor.h
@@ -45,6 +45,19 @@
 namespace s2e {
 namespace plugins {
 
+struct Range {
+	uint64_t start;
+	uint64_t end;
+	bool operator()(const Range &p1, const Range &p2) const {
+		return p1.start < p2.start;
+	}
+	bool operator==(const Range &p1) const {
+		return p1.start == start && p1.end == end;
+	}
+};
+typedef std::set<Range, Range> RangeEntries;
+
+
 /**
  *  Base class for default OS actions.
  *  It provides an interface for loading/unloading modules and processes.

--- a/qemu/s2e/S2EExecutionState.cpp
+++ b/qemu/s2e/S2EExecutionState.cpp
@@ -116,6 +116,7 @@ S2EExecutionState::S2EExecutionState(klee::KFunction *kf) :
         m_runningExceptionEmulationCode(false)
 {
     //XXX: make this a struct, not a pointer...
+	m_preparingstate = false;
     m_timersState = new TimersState;
     m_dirtyMaskObject = NULL;
 }
@@ -1946,7 +1947,8 @@ void S2EExecutionState::dmaRead(uint64_t hostAddress, uint8_t *buf, unsigned siz
         } else {
             concreteStore = os->getConcreteStore(true);
             for (unsigned i=0; i<length; ++i) {
-                if (_s2e_check_concrete(os, offset+i, 1)) {
+                //if (_s2e_check_concrete(os, offset+i, 1)) { // epeius has no choice to avoid segment fault but force to readRamConcrete (NOTE: too slow)
+                if (0) {
                     buf[i] = concreteStore[offset+i];
                 }else {
                     readRamConcrete(hostAddress+i, &buf[i], sizeof(buf[i]));

--- a/qemu/s2e/S2EExecutionState.h
+++ b/qemu/s2e/S2EExecutionState.h
@@ -109,6 +109,8 @@ struct S2EPhysCacheEntry
 
 class S2EExecutionState : public klee::ExecutionState
 {
+public:
+	bool m_preparingstate;//whether this is a prepare state
 protected:
     friend class S2EExecutor;
 
@@ -215,7 +217,9 @@ public:
     S2EDeviceState *getDeviceState() {
         return &m_deviceState;
     }
-
+    static void resetLastSymbolicId(){
+		s_lastSymbolicId = 0;
+	}
     TranslationBlock *getTb() const;
 
     uint64_t getTotalInstructionCount();

--- a/qemu/s2e/S2EExecutor.cpp
+++ b/qemu/s2e/S2EExecutor.cpp
@@ -1529,6 +1529,10 @@ S2EExecutionState* S2EExecutor::selectNextState(S2EExecutionState *state)
         vm_stop(RUN_STATE_SAVE_VM);
         doStateSwitch(state, newState);
         vm_start();
+        g_s2e->getCorePlugin()->onStateSwitchEnd.emit(state, newState);
+		if(newState->m_is_carry_on_state){
+			newState = selectNextState(newState);
+		}
     }
 
     //We can't free the state immediately if it is the current state.


### PR DESCRIPTION
Add fuzzing test capability to S2E as FuzzyS2E, enables S2E to exchange concrete testcases and some runtime information with AFL fuzzer. What's more, with the help of static analysis, S2E can determine whether we are stuck in a symbolic valued controlled loop, if so, S2E disables fork to avoid "state explosion" and generate a testcase for AFL so that the loop testing task can be done with AFL.