### PR TITLE
EFLAGS (env->mflags) bit 1 should be set.

### DIFF
--- a/qemu/target-i386/helper.c
+++ b/qemu/target-i386/helper.c
@@ -84,7 +84,7 @@ void cpu_state_reset(CPUX86State *env)
 
     WR_cpu(env, cc_op, CC_OP_EFLAGS);
     WR_cpu(env, cc_src, 0);
-    env->mflags = 0;
+    env->mflags = 2;
     env->df = 1;
     //WR_cpu(env, eflags, 0x2);
 

--- a/qemu/target-i386/op_helper.c
+++ b/qemu/target-i386/op_helper.c
@@ -175,7 +175,7 @@ static inline void s2e_load_eflags(void *mgr, void *eflags, int update_mask)
                     s2e_expr_and(mgr, eflags, MFLAGS_MASK & update_mask)
                     );
 
-    env->mflags = (env->mflags & ~update_mask) | concrete_flags;
+    env->mflags = (env->mflags & ~update_mask) | concrete_flags | 0x2;
 }
 
 #endif
@@ -190,7 +190,7 @@ static inline void load_eflags(int eflags, int update_mask)
         (eflags & update_mask) | 0x2);
     */
     env->mflags = (env->mflags & ~update_mask) |
-                    (eflags & MFLAGS_MASK & update_mask);
+                    (eflags & MFLAGS_MASK & update_mask) | 0x2;
 
 #if 0
     //Original QEMU code


### PR DESCRIPTION
Modified cpu_state_reset, s2e_load_eflags, and load_eflags to set EFLAGS bit 1.  In the Intel 64 and IA-32 Architecture Software Developer's Manual, Volume 1: Basic Architecture, Chapter 3 Basic Execution Environment, Section 3.4.3 EFLAGS Register it states that EFLAGS should be initialized to 02H and that EFLAGS bit 1 is reserved.

Signed-off-by: