### PR TITLE
Backport fixes from QEMU master to fix Windows 64-bit

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -63,6 +63,14 @@ void cpu_loop_exit(CPUArchState *env)
     s2e_longjmp(env->jmp_env, 1);
 }
 
+void cpu_loop_exit_restore(CPUArchState *env, uintptr_t pc)
+{
+    if (pc) {
+        cpu_restore_state(env->current_tb, env, pc);
+    }
+    s2e_longjmp(env->jmp_env, 1);
+}
+
 /* exit the current TB from a signal handler. The host registers are
    restored in a state compatible with the CPU emulator
  */

--- a/qemu/exec-all.h
+++ b/qemu/exec-all.h
@@ -116,6 +116,7 @@ TranslationBlock *tb_gen_code(CPUArchState *env,
                               int cflags);
 void cpu_exec_init(CPUArchState *env);
 void QEMU_NORETURN cpu_loop_exit(CPUArchState *env1);
+void QEMU_NORETURN cpu_loop_exit_restore(CPUArchState *env1, uintptr_t pc);
 int page_unprotect(target_ulong address, uintptr_t pc, void *puc);
 void tb_invalidate_phys_page_range(tb_page_addr_t start, tb_page_addr_t end,
                                    int is_cpu_write_access);

--- a/qemu/hw/apic.c
+++ b/qemu/hw/apic.c
@@ -194,7 +194,7 @@ void apic_deliver_pic_intr(DeviceState *d, int level)
             reset_bit(s->irr, lvt & 0xff);
             /* fall through */
         case APIC_DM_EXTINT:
-            cpu_reset_interrupt(s->cpu_env, CPU_INTERRUPT_HARD);
+            apic_update_irq(s);
             break;
         }
     }
@@ -371,9 +371,9 @@ static void apic_update_irq(APICCommonState *s)
     }
     if (apic_irq_pending(s) > 0) {
         cpu_interrupt(s->cpu_env, CPU_INTERRUPT_HARD);
-    } else if (apic_accept_pic_intr(&s->busdev.qdev) &&
-               pic_get_output(isa_pic)) {
-        apic_deliver_pic_intr(&s->busdev.qdev, 1);
+    } else if (!apic_accept_pic_intr(&s->busdev.qdev) ||
+               !pic_get_output(isa_pic)) {
+        cpu_reset_interrupt(s->cpu_env, CPU_INTERRUPT_HARD);
     }
 }
 

--- a/qemu/target-i386/cpu.h
+++ b/qemu/target-i386/cpu.h
@@ -1151,8 +1151,12 @@ void cpu_x86_inject_mce(Monitor *mon, CPUX86State *cenv, int bank,
 void do_interrupt(CPUX86State *env);
 void do_interrupt_x86_hardirq(CPUX86State *env, int intno, int is_hw);
 void QEMU_NORETURN raise_exception_env(int exception_index, CPUX86State *nenv);
+void QEMU_NORETURN raise_exception_ra(CPUX86State *nenv, int exception_index,
+                                        uintptr_t retaddr);
 void QEMU_NORETURN raise_exception_err_env(CPUX86State *nenv, int exception_index,
                                            int error_code);
+void QEMU_NORETURN raise_exception_err_ra(CPUX86State *nenv, int exception_index,
+                                            int error_code, uintptr_t retaddr);
 
 void do_smm_enter(CPUX86State *env1);
 

--- a/qemu/target-i386/cpuid.c
+++ b/qemu/target-i386/cpuid.c
@@ -255,7 +255,7 @@ typedef struct x86_def_t {
           CPUID_PAE | CPUID_MCE | CPUID_CX8 | CPUID_APIC | CPUID_SEP | \
           CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_CMOV | CPUID_PAT | \
           CPUID_PSE36 | CPUID_CLFLUSH | CPUID_ACPI | CPUID_MMX | \
-          CPUID_FXSR | CPUID_SSE | CPUID_SSE2 | CPUID_SS)
+          CPUID_FXSR | CPUID_SSE | CPUID_SSE2 | CPUID_SS | CPUID_DE)
           /* partly implemented:
           CPUID_MTRR, CPUID_MCA, CPUID_CLFLUSH (needed for Win64)
           CPUID_PSE36 (needed for Solaris) */

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -4670,21 +4670,17 @@ static target_ulong disas_insn(DisasContext *s, target_ulong pc_start)
         case 6: /* div */
             switch(ot) {
             case OT_BYTE:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_divb_AL(cpu_T[0]);
                 break;
             case OT_WORD:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_divw_AX(cpu_T[0]);
                 break;
             default:
             case OT_LONG:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_divl_EAX(cpu_T[0]);
                 break;
 #ifdef TARGET_X86_64
             case OT_QUAD:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_divq_EAX(cpu_T[0]);
                 break;
 #endif
@@ -4693,21 +4689,17 @@ static target_ulong disas_insn(DisasContext *s, target_ulong pc_start)
         case 7: /* idiv */
             switch(ot) {
             case OT_BYTE:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_idivb_AL(cpu_T[0]);
                 break;
             case OT_WORD:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_idivw_AX(cpu_T[0]);
                 break;
             default:
             case OT_LONG:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_idivl_EAX(cpu_T[0]);
                 break;
 #ifdef TARGET_X86_64
             case OT_QUAD:
-                gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_idivq_EAX(cpu_T[0]);
                 break;
 #endif


### PR DESCRIPTION
This pull request backports commits from QEMU master to both:

- Advertise the Debug Extensions flag in the TCG
- Fix unaligned self-modifying writes which cross page boundaries (as discovered by Patrick Hulin)

This enables at least Windows 7 and 10 64-bit to boot in both normal and s2e mode in QEMU. A detailed explanation of the latter fix is available in the QEMU commit (http://git.qemu.org/?p=qemu.git;a=commit;h=81daabaf7a572f138a8b88ba6eea556bdb0cce46). Thanks!