### PR TITLE
Fix #97 : Clean exception_index after an interrupt request has been processed.

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -563,6 +563,12 @@ int cpu_exec(CPUArchState *env)
                     env->exception_index = EXCP_INTERRUPT;
                     cpu_loop_exit(env);
                 }
+#if defined(CONFIG_S2E)
+                /* Ensures that exception_index is cleaned when
+                   S2E leaves the cpu loop and goes back to
+                   exception handling */
+                env->exception_index = -1;
+#endif
 #if defined(DEBUG_DISAS) || defined(CONFIG_DEBUG_EXEC)
                 if (qemu_loglevel_mask(CPU_LOG_TB_CPU)) {
                     /* restore flags in standard format */


### PR DESCRIPTION
Explanation can be found [https://github.com/dslab-epfl/s2e/issues/97](in the issue).