### PR TITLE
Update S2EExecutor.cpp, add 'cpu_loop_exit_restore' as external call

### DIFF
--- a/qemu/s2e/S2EExecutor.cpp
+++ b/qemu/s2e/S2EExecutor.cpp
@@ -696,6 +696,7 @@ S2EExecutor::S2EExecutor(S2E* s2e, TCGLLVMContext *tcgLLVMContext,
     __DEFINE_EXT_FUNCTION(cpu_restore_state)
     __DEFINE_EXT_FUNCTION(cpu_abort)
     __DEFINE_EXT_FUNCTION(cpu_loop_exit)
+    __DEFINE_EXT_FUNCTION(cpu_loop_exit_restore)
 
     __DEFINE_EXT_FUNCTION(tb_find_pc)
 


### PR DESCRIPTION
s2eexecutor: add 'cpu_loop_exit_restore' as external call, or KLEE may error out with "KLEE: ERROR: failed external call: cpu_loop_exit_restore"
