### PR TITLE
target-i386: Reset current_tb in cpu_loop_exit_restore

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -68,6 +68,7 @@ void cpu_loop_exit_restore(CPUArchState *env, uintptr_t pc)
     if (pc) {
         cpu_restore_state(env->current_tb, env, pc);
     }
+    env->current_tb = NULL;
     s2e_longjmp(env->jmp_env, 1);
 }
 


### PR DESCRIPTION
This is a patch which fixes a bug introduced by
commit 90c3d101c3966aaffb8dd98d8bab55d3ce82abc4. Without this patch,
a tlb assertion failure in S2EExecutionState.cpp sporadically triggers,
causing a crash. In newer versions of qemu, this is handled in a
separate part of qemu, and so it wasn't originally part of the backport.

The specific assertion error is:

```qemu-system-i386: /home/sdamashek/s2e/s2e/qemu/s2e/S2EExecutionState.cpp:2022: void s2e::S2EExecutionState::flushTlbCachePage(klee::ObjectState *, int, int): Assertion `tlbIt != m_tlbMap.end()' failed.```